### PR TITLE
feat: 회원가입 기능 구현

### DIFF
--- a/src/main/java/com/example/seolab/controller/AuthController.java
+++ b/src/main/java/com/example/seolab/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.example.seolab.controller;
 
 import com.example.seolab.dto.request.LoginRequest;
+import com.example.seolab.dto.request.SignUpRequest;
 import com.example.seolab.dto.response.LoginResponse;
+import com.example.seolab.dto.response.SignUpResponse;
 import com.example.seolab.dto.response.TokenResponse;
 import com.example.seolab.service.AuthService;
 import jakarta.servlet.http.Cookie;
@@ -9,6 +11,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -52,5 +56,11 @@ public class AuthController {
 	public ResponseEntity<Void> logout(HttpServletResponse response) {
 		authService.logout(response);
 		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/signup")
+	public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
+		SignUpResponse signUpResponse = authService.signUp(signUpRequest);
+		return ResponseEntity.status(HttpStatus.CREATED).body(signUpResponse);
 	}
 }

--- a/src/main/java/com/example/seolab/dto/request/SignUpRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/SignUpRequest.java
@@ -1,0 +1,24 @@
+package com.example.seolab.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignUpRequest {
+
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	private String email;
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	@Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+	private String password;
+}

--- a/src/main/java/com/example/seolab/dto/response/SignUpResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/SignUpResponse.java
@@ -1,0 +1,17 @@
+package com.example.seolab.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpResponse {
+	private String email;
+	private String username;
+}

--- a/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
@@ -45,6 +45,14 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
 	}
 
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<Map<String, String>> handleIllegalArgumentException(
+		IllegalArgumentException ex) {
+		Map<String, String> error = new HashMap<>();
+		error.put("message", ex.getMessage());
+		return ResponseEntity.badRequest().body(error);
+	}
+
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<Map<String, String>> handleGlobalException(
 		Exception ex) {

--- a/src/main/java/com/example/seolab/service/AuthService.java
+++ b/src/main/java/com/example/seolab/service/AuthService.java
@@ -1,7 +1,9 @@
 package com.example.seolab.service;
 
 import com.example.seolab.dto.request.LoginRequest;
+import com.example.seolab.dto.request.SignUpRequest;
 import com.example.seolab.dto.response.LoginResponse;
+import com.example.seolab.dto.response.SignUpResponse;
 import com.example.seolab.dto.response.TokenResponse;
 import com.example.seolab.entity.User;
 import com.example.seolab.repository.UserRepository;
@@ -87,5 +89,29 @@ public class AuthService {
 		refreshTokenCookie.setPath("/");
 		refreshTokenCookie.setMaxAge(0);
 		response.addCookie(refreshTokenCookie);
+	}
+
+	public SignUpResponse signUp(SignUpRequest signUpRequest) {
+		// 이메일 중복 체크
+		if (userRepository.existsByEmail(signUpRequest.getEmail())) {
+			throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
+		}
+
+		// 이메일에서 username 추출 (@ 앞부분)
+		String username = signUpRequest.getEmail().split("@")[0];
+
+		// 사용자 생성
+		User user = User.builder()
+			.email(signUpRequest.getEmail())
+			.username(username)
+			.passwordHash(passwordEncoder.encode(signUpRequest.getPassword()))
+			.build();
+
+		User savedUser = userRepository.save(user);
+
+		return SignUpResponse.builder()
+			.email(savedUser.getEmail())
+			.username(savedUser.getUsername())
+			.build();
 	}
 }


### PR DESCRIPTION
##  작업 내용
사용자 회원가입 기능을 구현하여 새로운 사용자가 서비스에 가입할 수 있도록 했습니다.

##  구현 기능
- **회원가입 시스템**
 - 이메일/비밀번호 기반 회원가입
 - 이메일 중복 검사
 - username 자동 생성 (이메일 @ 앞부분)
 
- **API 엔드포인트**
 - `POST /api/auth/signup` - 신규 사용자 회원가입
 
- **데이터 검증**
 - 이메일 형식 검증
 - 비밀번호 최소 8자 이상 검증
 - 이메일 중복 체크

##  주요 변경사항
- SignUpRequest DTO (회원가입 요청 데이터)
- SignUpResponse DTO (회원가입 응답 데이터)
- AuthController에 signup 엔드포인트 추가
- AuthService에 signUp 메서드 구현
- GlobalExceptionHandler에 IllegalArgumentException 처리 추가

##  참고사항
- BCrypt로 비밀번호 암호화 저장
- 회원가입 성공 시 201 Created 상태 코드 반환
- 이메일 중복 시 400 Bad Request와 함께 에러 메시지 반환
- 회원가입 후 별도 로그인 필요 (자동 로그인 미구현)