### PR TITLE
fear: 사용자 정보 조회

### DIFF
--- a/src/main/java/com/example/seolab/controller/AuthController.java
+++ b/src/main/java/com/example/seolab/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.example.seolab.dto.request.SignUpRequest;
 import com.example.seolab.dto.response.LoginResponse;
 import com.example.seolab.dto.response.SignUpResponse;
 import com.example.seolab.dto.response.TokenResponse;
+import com.example.seolab.dto.response.UserInfoResponse;
 import com.example.seolab.service.AuthService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -62,5 +64,11 @@ public class AuthController {
 	public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
 		SignUpResponse signUpResponse = authService.signUp(signUpRequest);
 		return ResponseEntity.status(HttpStatus.CREATED).body(signUpResponse);
+	}
+
+	@GetMapping("/me")
+	public ResponseEntity<UserInfoResponse> getCurrentUser(Authentication authentication) {
+		UserInfoResponse userInfo = authService.getCurrentUser(authentication);
+		return ResponseEntity.ok(userInfo);
 	}
 }

--- a/src/main/java/com/example/seolab/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/UserInfoResponse.java
@@ -1,0 +1,17 @@
+package com.example.seolab.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserInfoResponse {
+	private String email;
+	private String username;
+}

--- a/src/main/java/com/example/seolab/entity/User.java
+++ b/src/main/java/com/example/seolab/entity/User.java
@@ -73,7 +73,12 @@ public class User implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		return email; // 이메일을 username으로 사용
+		return email; // Spring Security를 위해 이메일을 username으로 사용
+	}
+
+	// 실제 사용자명을 반환하는 메서드 추가
+	public String getDisplayName() {
+		return username;
 	}
 
 	@Override

--- a/src/main/java/com/example/seolab/service/AuthService.java
+++ b/src/main/java/com/example/seolab/service/AuthService.java
@@ -5,6 +5,7 @@ import com.example.seolab.dto.request.SignUpRequest;
 import com.example.seolab.dto.response.LoginResponse;
 import com.example.seolab.dto.response.SignUpResponse;
 import com.example.seolab.dto.response.TokenResponse;
+import com.example.seolab.dto.response.UserInfoResponse;
 import com.example.seolab.entity.User;
 import com.example.seolab.repository.UserRepository;
 import com.example.seolab.security.JwtUtil;
@@ -13,6 +14,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -56,7 +58,7 @@ public class AuthService {
 		return LoginResponse.builder()
 			.accessToken(accessToken)
 			.email(user.getEmail())
-			.username(user.getUsername())
+			.username(user.getDisplayName()) // 실제 username 필드 반환
 			.build();
 	}
 
@@ -111,7 +113,18 @@ public class AuthService {
 
 		return SignUpResponse.builder()
 			.email(savedUser.getEmail())
-			.username(savedUser.getUsername())
+			.username(savedUser.getDisplayName()) // 실제 username 필드 반환
+			.build();
+	}
+
+	public UserInfoResponse getCurrentUser(Authentication authentication) {
+		String email = authentication.getName();
+		User user = userRepository.findByEmail(email)
+			.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+		return UserInfoResponse.builder()
+			.email(user.getEmail())
+			.username(user.getDisplayName()) // 실제 username 필드 반환
 			.build();
 	}
 }


### PR DESCRIPTION
## 작업 내용
사용자 정보를 조회할 수 있는 `/api/auth/me` 를 추가했습니다.

## 구현 기능
- **사용자 정보 조회 API**
  - `GET /api/auth/me` - 현재 로그인한 사용자 정보 조회
  - JWT 토큰을 통한 사용자 인증 확인
  - 사용자 이메일, 사용자 이름 응답

## 주요 변경사항
- **AuthController**
  - `getCurrentUser()` 메서드 추가
  - Authentication 객체를 통한 현재 사용자 정보 추출

- **AuthService**
  - `getCurrentUser()` 메서드 구현
  - 인증된 사용자의 이메일을 통한 사용자 조회

- **UserInfoResponse DTO**
  - 사용자 정보 응답을 위한 DTO 클래스 추가
  - email, username 필드 포함

## 참고사항
- 인증이 필요한 엔드포인트로 JWT 토큰 필수
- 토큰이 유효하지 않은 경우 401 에러 반환
- 사용자 정보 변경은 별도 API에서 처리 예정