### PR TITLE
fix: jwt 토큰이 없거나 잘못된 토큰인 경우 처리 개선

### DIFF
--- a/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.seolab.exception;
 
+import io.jsonwebtoken.JwtException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -60,5 +61,12 @@ public class GlobalExceptionHandler {
 		Map<String, String> error = new HashMap<>();
 		error.put("message", "서버 오류가 발생했습니다.");
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+	}
+
+	@ExceptionHandler({JwtException.class, io.jsonwebtoken.security.SecurityException.class})
+	public ResponseEntity<Map<String, String>> handleJwtException(Exception ex) {
+		Map<String, String> error = new HashMap<>();
+		error.put("message", "유효하지 않은 토큰입니다.");
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
 	}
 }


### PR DESCRIPTION
## 작업 내용
JWT 토큰 관련 예외처리를 개선, 잘못된 토큰이나 토큰없이 요청시 Unauthorized 응답을 반황하도록 수정했습니다.

## 문제 상황
- `/api/auth/me` 엔드포인트에 잘못된 토큰으로 요청 시 500 Internal Server Error 발생
- JWT 토큰 파싱 과정에서 발생하는 예외가 제대로 처리되지 않음
- 클라이언트에서 인증 실패를 정확히 판단하기 어려움

## 해결 방법
### 1. JwtAuthenticationFilter 예외 처리 강화
- JWT 토큰 파싱할 때 발생하는 예외 캐치
- 예외 발생시 로그만 남기고 필터 체인 계속 진행
- Spring Security가 인증되지 않은 요청에 대해 자동으로 401 반환하도록

### 2. GlobalExceptionHandler JWT 예외 핸들러 추가
- `JwtException`, `SecurityException` 예외에 대한 핸들러 추가
- 일관된 에러 메시지와 401 상태 코드 반환