### PR TITLE
fix: 회원 가입시 validation 처리 추가, 에러 응답 메세지 통일화

### DIFF
--- a/src/main/java/com/example/seolab/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/LoginRequest.java
@@ -19,6 +19,6 @@ public class LoginRequest {
 	private String email;
 
 	@NotBlank(message = "비밀번호는 필수입니다.")
-	@Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+	@Size(min = 8, max = 20,message = "비밀번호는 8-20자 사이여야 합니다.")
 	private String password;
 }

--- a/src/main/java/com/example/seolab/dto/request/SignUpRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/SignUpRequest.java
@@ -1,8 +1,7 @@
 package com.example.seolab.dto.request;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,10 +14,16 @@ import lombok.Setter;
 public class SignUpRequest {
 
 	@NotBlank(message = "이메일은 필수입니다.")
-	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	@Pattern(
+		regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+		message = "올바른 이메일 형식이 아닙니다."
+	)
 	private String email;
 
 	@NotBlank(message = "비밀번호는 필수입니다.")
-	@Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+	@Pattern(
+		regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
+		message = "올바른 비밀번호 형식이 아닙니다. (최소 8-20자, 대소문자, 숫자, 특수문자 각 1개 이상)"
+	)
 	private String password;
 }


### PR DESCRIPTION
## 작업 내용
회원가입,로그인시 validation 처리와 에러 응답 메시지를 통일화했습니다.

## 구현 기능
- **Validation 추가**
  - **로그인**: 비밀번호 길이 제한을 8자 이상에서 8-20자 사이로
  - **회원가입**: 비밀번호 정규식 적용 (대소문자, 숫자, 특수문자 각 1개 이상, 8-20자), 이메일 형식 검증을 `@Email`에서 정규식 기반 `@Pattern`으로 변경

- **에러 응답 통일화**
  - `GlobalExceptionHandler`에서 validation 에러 처리 로직 개선
  - 여러 validation에러를 하나의 통합된 메시지로 변환
  - 이메일 중복오류시 409 Conflict 상태 코드 반환

## 참고사항
- **로그인**: 비밀번호 8-20자 길이 제한
- **회원가입**: 비밀번호 정규식 검증 (대소문자/숫자/특수문자 각 1개 이상, 8-20자), 이메일 정규식 검증
- 이메일 중복 에러는 409 Conflict로 구분