### PR TITLE
fix: 로그아웃 시 인증 검증 추가

### DIFF
--- a/src/main/java/com/example/seolab/controller/AuthController.java
+++ b/src/main/java/com/example/seolab/controller/AuthController.java
@@ -55,8 +55,9 @@ public class AuthController {
 	}
 
 	@PostMapping("/logout")
-	public ResponseEntity<Void> logout(HttpServletResponse response) {
-		authService.logout(response);
+	public ResponseEntity<Void> logout(HttpServletResponse response, Authentication authentication) {
+		// authentication이 null이면 Spring Security가 자동으로 401 반환
+		authService.logout(response, authentication);
 		return ResponseEntity.ok().build();
 	}
 


### PR DESCRIPTION
### 작업 내용
로그아웃 API에 인증 검증 로직을 추가했습니다.

### 구현 기능
- **인증 기반 로그아웃 시스템**
  - Authentication 파라미터 추가
  - 유효한 JWT 토큰을 가진 사용자만 로그아웃 가능
  - 인증 실패 시 401 Unauthorized 반환

### 주요 변경사항
- **AuthController.java**
  - logout 메서드에 Authentication 파라미터 추가
  - 인증되지 않은 요청 시 자동으로 401 반환

- **AuthService.java**
  - logout 메서드 시그니처 변경 (Authentication 파라미터 추가)
  - 로그아웃하는 사용자 식별 로직 추가

### 참고사항
- 기존 RefreshToken 쿠키 삭제 로직은 유지
- 로그아웃 후 AccessToken은 만료 시간까지 유효 (추후 블랙리스트를 적용할지 만료시간을 줄일지 고민 필요)