### PR TITLE
fix: 책 검색시 title, contents 에서 html entity 깨짐 수정

### DIFF
--- a/src/main/java/com/example/seolab/service/BookSearchService.java
+++ b/src/main/java/com/example/seolab/service/BookSearchService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.HtmlUtils;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -94,8 +95,8 @@ public class BookSearchService {
 
 	private BookDto convertToBookDto(KakaoBookSearchResponse.Document document) {
 		return BookDto.builder()
-			.title(document.getTitle())
-			.contents(document.getContents())
+			.title(HtmlUtils.htmlUnescape(document.getTitle()))
+			.contents(HtmlUtils.htmlUnescape(document.getContents()))
 			.isbn(document.getIsbn())
 			.publishedDate(parseDate(document.getDatetime()))
 			.authors(document.getAuthors())


### PR DESCRIPTION
##  작업 내용
책 검색 API에서 카카오 도서 검색 결과의 title과 contents에 포함된 HTML 엔티티 문자들이 제대로 변환되지 않던 문제를 수정했습니다.

## 구현 기능
- **HTML 엔티티 디코딩**
  - Spring의 HtmlUtils.htmlUnescape() 메서드 활용
  - title과 contents 필드에서 HTML 엔티티를 일반 문자로 변환

##  주요 변경사항
- **Import 추가**: `org.springframework.web.util.HtmlUtils`
- **BookSearchService.convertToBookDto()**: title과 contents 필드에 HtmlUtils.htmlUnescape() 적용