### PR TITLE
feat: 책 검색 후 서랍에 책을 저장하는 기능 및 즐겨찾기, 완독, 읽고있는책 리스트, 즐겨찾기 리스트 구현

### DIFF
--- a/src/main/java/com/example/seolab/controller/BookController.java
+++ b/src/main/java/com/example/seolab/controller/BookController.java
@@ -1,0 +1,85 @@
+package com.example.seolab.controller;
+
+import com.example.seolab.dto.request.AddBookRequest;
+import com.example.seolab.dto.response.AddBookResponse;
+import com.example.seolab.entity.User;
+import com.example.seolab.entity.UserBook;
+import com.example.seolab.service.UserBookService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/books")
+@RequiredArgsConstructor
+@Slf4j
+public class BookController {
+
+	private final UserBookService userBookService;
+
+	@PostMapping("/add")
+	public ResponseEntity<AddBookResponse> addBookToLibrary(
+		@Valid @RequestBody AddBookRequest request,
+		Authentication authentication) {
+
+		String userEmail = authentication.getName();
+		log.info("User {} is adding book: {}", userEmail, request.getBookInfo().getTitle());
+
+		// Authentication에서 실제 사용자 ID 추출
+		Long userId = getUserIdFromAuthentication(authentication);
+
+		AddBookResponse response = userBookService.addBookToUserLibrary(userId, request);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	@GetMapping("/reading")
+	public ResponseEntity<List<UserBook>> getReadingBooks(Authentication authentication) {
+		Long userId = getUserIdFromAuthentication(authentication);
+		List<UserBook> readingBooks = userBookService.getReadingBooks(userId);
+
+		return ResponseEntity.ok(readingBooks);
+	}
+
+	@GetMapping("/favorites")
+	public ResponseEntity<List<UserBook>> getFavoriteBooks(Authentication authentication) {
+		Long userId = getUserIdFromAuthentication(authentication);
+		List<UserBook> favoriteBooks = userBookService.getFavoriteBooks(userId);
+
+		return ResponseEntity.ok(favoriteBooks);
+	}
+
+	@PatchMapping("/{userBookId}/complete")
+	public ResponseEntity<UserBook> markBookAsCompleted(
+		@PathVariable Long userBookId,
+		Authentication authentication) {
+
+		Long userId = getUserIdFromAuthentication(authentication);
+		UserBook completedBook = userBookService.markBookAsCompleted(userId, userBookId);
+
+		return ResponseEntity.ok(completedBook);
+	}
+
+	@PatchMapping("/{userBookId}/favorite")
+	public ResponseEntity<UserBook> toggleFavorite(
+		@PathVariable Long userBookId,
+		Authentication authentication) {
+
+		Long userId = getUserIdFromAuthentication(authentication);
+		UserBook toggledBook = userBookService.toggleFavorite(userId, userBookId);
+
+		return ResponseEntity.ok(toggledBook);
+	}
+
+	private Long getUserIdFromAuthentication(Authentication authentication) {
+		// Spring Security에서 인증된 User 객체 가져오기
+		User user = (User) authentication.getPrincipal();
+		return user.getUserId();
+	}
+}

--- a/src/main/java/com/example/seolab/controller/BookController.java
+++ b/src/main/java/com/example/seolab/controller/BookController.java
@@ -2,8 +2,8 @@ package com.example.seolab.controller;
 
 import com.example.seolab.dto.request.AddBookRequest;
 import com.example.seolab.dto.response.AddBookResponse;
+import com.example.seolab.dto.response.UserBookResponse;
 import com.example.seolab.entity.User;
-import com.example.seolab.entity.UserBook;
 import com.example.seolab.service.UserBookService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,39 +40,39 @@ public class BookController {
 	}
 
 	@GetMapping("/reading")
-	public ResponseEntity<List<UserBook>> getReadingBooks(Authentication authentication) {
+	public ResponseEntity<List<UserBookResponse>> getReadingBooks(Authentication authentication) {
 		Long userId = getUserIdFromAuthentication(authentication);
-		List<UserBook> readingBooks = userBookService.getReadingBooks(userId);
+		List<UserBookResponse> readingBooks = userBookService.getReadingBooks(userId);
 
 		return ResponseEntity.ok(readingBooks);
 	}
 
 	@GetMapping("/favorites")
-	public ResponseEntity<List<UserBook>> getFavoriteBooks(Authentication authentication) {
+	public ResponseEntity<List<UserBookResponse>> getFavoriteBooks(Authentication authentication) {
 		Long userId = getUserIdFromAuthentication(authentication);
-		List<UserBook> favoriteBooks = userBookService.getFavoriteBooks(userId);
+		List<UserBookResponse> favoriteBooks = userBookService.getFavoriteBooks(userId);
 
 		return ResponseEntity.ok(favoriteBooks);
 	}
 
 	@PatchMapping("/{userBookId}/complete")
-	public ResponseEntity<UserBook> markBookAsCompleted(
+	public ResponseEntity<UserBookResponse> markBookAsCompleted(
 		@PathVariable Long userBookId,
 		Authentication authentication) {
 
 		Long userId = getUserIdFromAuthentication(authentication);
-		UserBook completedBook = userBookService.markBookAsCompleted(userId, userBookId);
+		UserBookResponse toggledBook = userBookService.markBookAsCompleted(userId, userBookId);
 
-		return ResponseEntity.ok(completedBook);
+		return ResponseEntity.ok(toggledBook);
 	}
 
 	@PatchMapping("/{userBookId}/favorite")
-	public ResponseEntity<UserBook> toggleFavorite(
+	public ResponseEntity<UserBookResponse> toggleFavorite(
 		@PathVariable Long userBookId,
 		Authentication authentication) {
 
 		Long userId = getUserIdFromAuthentication(authentication);
-		UserBook toggledBook = userBookService.toggleFavorite(userId, userBookId);
+		UserBookResponse toggledBook = userBookService.toggleFavorite(userId, userBookId);
 
 		return ResponseEntity.ok(toggledBook);
 	}

--- a/src/main/java/com/example/seolab/dto/request/AddBookRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/AddBookRequest.java
@@ -1,0 +1,41 @@
+package com.example.seolab.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddBookRequest {
+
+	@NotNull(message = "책 정보는 필수입니다.")
+	@Valid
+	private BookInfo bookInfo;
+
+	private LocalDate startDate;
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class BookInfo {
+
+		@NotNull(message = "책 제목은 필수입니다.")
+		private String title;
+
+		private String contents;
+		private String isbn;
+		private String publishedDate;
+		private java.util.List<String> authors;
+		private String publisher;
+		private java.util.List<String> translators;
+		private String thumbnail;
+	}
+}

--- a/src/main/java/com/example/seolab/dto/request/AddBookRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/AddBookRequest.java
@@ -14,12 +14,9 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AddBookRequest {
-
 	@NotNull(message = "책 정보는 필수입니다.")
 	@Valid
 	private BookInfo bookInfo;
-
-	private LocalDate startDate;
 
 	@Getter
 	@Setter
@@ -32,7 +29,7 @@ public class AddBookRequest {
 
 		private String contents;
 		private String isbn;
-		private String publishedDate;
+		private String publishedDate; // ISO 형태 문자열
 		private java.util.List<String> authors;
 		private String publisher;
 		private java.util.List<String> translators;

--- a/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
@@ -1,0 +1,49 @@
+package com.example.seolab.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AddBookResponse {
+
+	private Long userBookId;
+
+	private BookDetail book;
+
+	private LocalDate startDate;
+
+	private String readingStatus;
+
+	private Boolean isFavorite;
+
+	private LocalDateTime createdAt;
+
+	private String message;
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class BookDetail {
+		private Long bookId;
+		private String title;
+		private String author;
+		private String publisher;
+		private String isbn;
+		private String description;
+		private String coverImage;
+		private LocalDate publishedDate;
+	}
+}

--- a/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
@@ -8,29 +8,28 @@ import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class AddBookResponse {
-
+public class UserBookResponse {
 	private Long userBookId;
-	private BookDetail book;
+	private BookInfo book;
 	private LocalDate startDate;
-	private String readingStatus;
+	private LocalDate endDate;
 	private Boolean isFavorite;
+	private String readingStatus;
 	private LocalDateTime createdAt;
-	private String message;
+	private LocalDateTime updatedAt;
 
 	@Getter
 	@Setter
 	@NoArgsConstructor
 	@AllArgsConstructor
 	@Builder
-	public static class BookDetail {
+	public static class BookInfo {
 		private Long bookId;
 		private String title;
 		private String author;

--- a/src/main/java/com/example/seolab/entity/Book.java
+++ b/src/main/java/com/example/seolab/entity/Book.java
@@ -1,0 +1,61 @@
+package com.example.seolab.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+	name = "books",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "unique_book",
+			columnNames = {"title", "author", "publisher"}
+		)
+	}
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Book {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "book_id")
+	private Long bookId;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String author;
+
+	private String publisher;
+
+	private String isbn;
+
+	@Column(columnDefinition = "TEXT")
+	private String description;
+
+	@Column(name = "cover_image")
+	private String coverImage;
+
+	@Column(name = "published_date")
+	private LocalDate publishedDate;
+
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@PrePersist
+	protected void onCreate() {
+		createdAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/example/seolab/entity/UserBook.java
+++ b/src/main/java/com/example/seolab/entity/UserBook.java
@@ -40,9 +40,6 @@ public class UserBook {
 	@JoinColumn(name = "book_id", nullable = false)
 	private Book book;
 
-	@Column(name = "start_date", nullable = false)
-	private LocalDate startDate;
-
 	@Column(name = "end_date")
 	private LocalDate endDate;
 
@@ -65,10 +62,6 @@ public class UserBook {
 	protected void onCreate() {
 		createdAt = LocalDateTime.now();
 		updatedAt = LocalDateTime.now();
-
-		if (startDate == null) {
-			startDate = LocalDate.now();
-		}
 	}
 
 	@PreUpdate
@@ -91,9 +84,20 @@ public class UserBook {
 		}
 	}
 
-	public void markAsCompleted() {
-		this.readingStatus = ReadingStatus.COMPLETED;
-		this.endDate = LocalDate.now();
+	public LocalDate getStartDate() {
+		return createdAt != null ? createdAt.toLocalDate() : null;
+	}
+
+	public void toggleReadingStatus() {
+		if (this.readingStatus == ReadingStatus.READING) {
+			// 읽는중 → 완료
+			this.readingStatus = ReadingStatus.COMPLETED;
+			this.endDate = LocalDate.now();
+		} else {
+			// 완료 → 읽는중
+			this.readingStatus = ReadingStatus.READING;
+			this.endDate = null; // 완독일 제거
+		}
 	}
 
 	public void toggleFavorite() {

--- a/src/main/java/com/example/seolab/entity/UserBook.java
+++ b/src/main/java/com/example/seolab/entity/UserBook.java
@@ -1,0 +1,110 @@
+package com.example.seolab.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+	name = "user_books",
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "unique_user_book",
+			columnNames = {"user_id", "book_id"}
+		)
+	}
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserBook {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "user_book_id")
+	private Long userBookId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "book_id", nullable = false)
+	private Book book;
+
+	@Column(name = "start_date", nullable = false)
+	private LocalDate startDate;
+
+	@Column(name = "end_date")
+	private LocalDate endDate;
+
+	@Column(name = "is_favorite")
+	@Builder.Default
+	private Boolean isFavorite = false;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "reading_status")
+	@Builder.Default
+	private ReadingStatus readingStatus = ReadingStatus.READING;
+
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		createdAt = LocalDateTime.now();
+		updatedAt = LocalDateTime.now();
+
+		if (startDate == null) {
+			startDate = LocalDate.now();
+		}
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		updatedAt = LocalDateTime.now();
+	}
+
+	public enum ReadingStatus {
+		READING("reading"),
+		COMPLETED("completed");
+
+		private final String value;
+
+		ReadingStatus(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+	}
+
+	public void markAsCompleted() {
+		this.readingStatus = ReadingStatus.COMPLETED;
+		this.endDate = LocalDate.now();
+	}
+
+	public void toggleFavorite() {
+		this.isFavorite = !this.isFavorite;
+	}
+
+	public boolean isReading() {
+		return this.readingStatus == ReadingStatus.READING;
+	}
+
+	public boolean isCompleted() {
+		return this.readingStatus == ReadingStatus.COMPLETED;
+	}
+}

--- a/src/main/java/com/example/seolab/repository/BookRepository.java
+++ b/src/main/java/com/example/seolab/repository/BookRepository.java
@@ -11,46 +11,15 @@ import java.util.Optional;
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long> {
 
-	/**
-	 * ISBN으로 책 찾기
-	 * @param isbn ISBN 번호
-	 * @return 찾은 책 (Optional)
-	 */
+
 	Optional<Book> findByIsbn(String isbn);
 
-	/**
-	 * 제목, 저자, 출판사 조합으로 책 찾기
-	 * @param title 책 제목
-	 * @param author 저자
-	 * @param publisher 출판사
-	 * @return 찾은 책 (Optional)
-	 */
 	Optional<Book> findByTitleAndAuthorAndPublisher(String title, String author, String publisher);
 
-	/**
-	 * ISBN이 존재하는지 확인
-	 * @param isbn ISBN 번호
-	 * @return 존재 여부
-	 */
 	boolean existsByIsbn(String isbn);
 
-	/**
-	 * 제목, 저자, 출판사 조합이 존재하는지 확인
-	 * @param title 책 제목
-	 * @param author 저자
-	 * @param publisher 출판사
-	 * @return 존재 여부
-	 */
 	boolean existsByTitleAndAuthorAndPublisher(String title, String author, String publisher);
 
-	/**
-	 * ISBN 또는 제목+저자+출판사로 책 찾기 (복합 검색)
-	 * @param isbn ISBN 번호
-	 * @param title 책 제목
-	 * @param author 저자
-	 * @param publisher 출판사
-	 * @return 찾은 책 (Optional)
-	 */
 	@Query("SELECT b FROM Book b WHERE " +
 		"(b.isbn = :isbn AND :isbn IS NOT NULL) OR " +
 		"(b.title = :title AND b.author = :author AND b.publisher = :publisher)")

--- a/src/main/java/com/example/seolab/repository/BookRepository.java
+++ b/src/main/java/com/example/seolab/repository/BookRepository.java
@@ -1,0 +1,63 @@
+package com.example.seolab.repository;
+
+import com.example.seolab.entity.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BookRepository extends JpaRepository<Book, Long> {
+
+	/**
+	 * ISBN으로 책 찾기
+	 * @param isbn ISBN 번호
+	 * @return 찾은 책 (Optional)
+	 */
+	Optional<Book> findByIsbn(String isbn);
+
+	/**
+	 * 제목, 저자, 출판사 조합으로 책 찾기
+	 * @param title 책 제목
+	 * @param author 저자
+	 * @param publisher 출판사
+	 * @return 찾은 책 (Optional)
+	 */
+	Optional<Book> findByTitleAndAuthorAndPublisher(String title, String author, String publisher);
+
+	/**
+	 * ISBN이 존재하는지 확인
+	 * @param isbn ISBN 번호
+	 * @return 존재 여부
+	 */
+	boolean existsByIsbn(String isbn);
+
+	/**
+	 * 제목, 저자, 출판사 조합이 존재하는지 확인
+	 * @param title 책 제목
+	 * @param author 저자
+	 * @param publisher 출판사
+	 * @return 존재 여부
+	 */
+	boolean existsByTitleAndAuthorAndPublisher(String title, String author, String publisher);
+
+	/**
+	 * ISBN 또는 제목+저자+출판사로 책 찾기 (복합 검색)
+	 * @param isbn ISBN 번호
+	 * @param title 책 제목
+	 * @param author 저자
+	 * @param publisher 출판사
+	 * @return 찾은 책 (Optional)
+	 */
+	@Query("SELECT b FROM Book b WHERE " +
+		"(b.isbn = :isbn AND :isbn IS NOT NULL) OR " +
+		"(b.title = :title AND b.author = :author AND b.publisher = :publisher)")
+	Optional<Book> findByIsbnOrTitleAndAuthorAndPublisher(
+		@Param("isbn") String isbn,
+		@Param("title") String title,
+		@Param("author") String author,
+		@Param("publisher") String publisher
+	);
+}

--- a/src/main/java/com/example/seolab/repository/UserBookRepository.java
+++ b/src/main/java/com/example/seolab/repository/UserBookRepository.java
@@ -33,6 +33,4 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
 		"ORDER BY ub.updatedAt DESC")
 	List<UserBook> findRecentReadingBooks(@Param("userId") Long userId,
 		@Param("status") ReadingStatus status);
-
-	List<UserBook> findByUserUserIdOrderByStartDateDesc(Long userId);
 }

--- a/src/main/java/com/example/seolab/repository/UserBookRepository.java
+++ b/src/main/java/com/example/seolab/repository/UserBookRepository.java
@@ -1,0 +1,38 @@
+package com.example.seolab.repository;
+
+import com.example.seolab.entity.UserBook;
+import com.example.seolab.entity.UserBook.ReadingStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserBookRepository extends JpaRepository<UserBook, Long> {
+
+	Optional<UserBook> findByUserUserIdAndBookBookId(Long userId, Long bookId);
+
+	boolean existsByUserUserIdAndBookBookId(Long userId, Long bookId);
+
+	List<UserBook> findByUserUserIdOrderByCreatedAtDesc(Long userId);
+
+	List<UserBook> findByUserUserIdAndReadingStatusOrderByCreatedAtDesc(Long userId, ReadingStatus readingStatus);
+
+	List<UserBook> findByUserUserIdAndIsFavoriteTrueOrderByCreatedAtDesc(Long userId);
+
+	long countByUserUserIdAndReadingStatus(Long userId, ReadingStatus readingStatus);
+
+	Optional<UserBook> findTopByUserUserIdOrderByCreatedAtDesc(Long userId);
+
+	@Query("SELECT ub FROM UserBook ub " +
+		"WHERE ub.user.userId = :userId " +
+		"AND ub.readingStatus = :status " +
+		"ORDER BY ub.updatedAt DESC")
+	List<UserBook> findRecentReadingBooks(@Param("userId") Long userId,
+		@Param("status") ReadingStatus status);
+
+	List<UserBook> findByUserUserIdOrderByStartDateDesc(Long userId);
+}

--- a/src/main/java/com/example/seolab/service/BookService.java
+++ b/src/main/java/com/example/seolab/service/BookService.java
@@ -1,0 +1,142 @@
+package com.example.seolab.service;
+
+import com.example.seolab.dto.response.BookDto;
+import com.example.seolab.entity.Book;
+import com.example.seolab.repository.BookRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class BookService {
+
+	private final BookRepository bookRepository;
+
+	/**
+	 * 책을 찾거나 새로 생성하는 메서드
+	 * @param bookDto 카카오 API에서 받은 책 정보
+	 * @return 기존 책 또는 새로 생성된 책
+	 */
+	public Book findOrCreateBook(BookDto bookDto) {
+		log.info("Finding or creating book: {}", bookDto.getTitle());
+
+		// 1. ISBN으로 먼저 찾기 (있는 경우)
+		String firstIsbn = extractFirstIsbn(bookDto.getIsbn());
+		if (StringUtils.hasText(firstIsbn)) {
+			Optional<Book> existingByIsbn = bookRepository.findByIsbn(firstIsbn);
+			if (existingByIsbn.isPresent()) {
+				log.info("Found existing book by ISBN: {}", firstIsbn);
+				return existingByIsbn.get();
+			}
+		}
+
+		// 2. title + author + publisher 조합으로 찾기
+		String firstAuthor = getFirstAuthor(bookDto);
+		if (StringUtils.hasText(bookDto.getTitle()) &&
+			StringUtils.hasText(firstAuthor) &&
+			StringUtils.hasText(bookDto.getPublisher())) {
+
+			Optional<Book> existingByTitleAuthorPublisher =
+				bookRepository.findByTitleAndAuthorAndPublisher(
+					bookDto.getTitle(),
+					firstAuthor,
+					bookDto.getPublisher()
+				);
+
+			if (existingByTitleAuthorPublisher.isPresent()) {
+				log.info("Found existing book by title/author/publisher: {}", bookDto.getTitle());
+				return existingByTitleAuthorPublisher.get();
+			}
+		}
+
+		// 3. 새로운 책 생성
+		log.info("Creating new book: {}", bookDto.getTitle());
+		return createNewBook(bookDto);
+	}
+
+	/**
+	 * 새로운 책을 생성하는 메서드
+	 * @param bookDto 책 정보
+	 * @return 생성된 책
+	 */
+	private Book createNewBook(BookDto bookDto) {
+		Book book = Book.builder()
+			.title(bookDto.getTitle())
+			.author(getFirstAuthor(bookDto))
+			.publisher(bookDto.getPublisher())
+			.isbn(extractFirstIsbn(bookDto.getIsbn()))
+			.description(bookDto.getContents())
+			.coverImage(bookDto.getThumbnail())
+			.publishedDate(bookDto.getPublishedDate())
+			.build();
+
+		Book savedBook = bookRepository.save(book);
+		log.info("Created new book with ID: {}", savedBook.getBookId());
+
+		return savedBook;
+	}
+
+	/**
+	 * ISBN 문자열에서 첫 번째 ISBN을 추출하는 메서드
+	 * 예: "8968488703 9788968488702" → "8968488703"
+	 * @param isbn ISBN 문자열
+	 * @return 첫 번째 ISBN 또는 null
+	 */
+	private String extractFirstIsbn(String isbn) {
+		if (!StringUtils.hasText(isbn)) {
+			return null;
+		}
+
+		String trimmedIsbn = isbn.trim();
+		if (trimmedIsbn.contains(" ")) {
+			return trimmedIsbn.split(" ")[0];
+		}
+
+		return trimmedIsbn;
+	}
+
+	/**
+	 * 저자 리스트에서 첫 번째 저자를 가져오는 메서드
+	 * @param bookDto 책 정보
+	 * @return 첫 번째 저자 또는 빈 문자열
+	 */
+	private String getFirstAuthor(BookDto bookDto) {
+		if (bookDto.getAuthors() == null || bookDto.getAuthors().isEmpty()) {
+			return "";
+		}
+		return bookDto.getAuthors().get(0);
+	}
+
+	/**
+	 * ID로 책 조회
+	 * @param bookId 책 ID
+	 * @return 책 정보
+	 */
+	@Transactional(readOnly = true)
+	public Book findBookById(Long bookId) {
+		return bookRepository.findById(bookId)
+			.orElseThrow(() -> new IllegalArgumentException("책을 찾을 수 없습니다: " + bookId));
+	}
+
+	/**
+	 * ISBN으로 책 조회
+	 * @param isbn ISBN
+	 * @return 책 정보
+	 */
+	@Transactional(readOnly = true)
+	public Optional<Book> findBookByIsbn(String isbn) {
+		String firstIsbn = extractFirstIsbn(isbn);
+		if (!StringUtils.hasText(firstIsbn)) {
+			return Optional.empty();
+		}
+		return bookRepository.findByIsbn(firstIsbn);
+	}
+}

--- a/src/main/java/com/example/seolab/service/BookService.java
+++ b/src/main/java/com/example/seolab/service/BookService.java
@@ -20,11 +20,6 @@ public class BookService {
 
 	private final BookRepository bookRepository;
 
-	/**
-	 * 책을 찾거나 새로 생성하는 메서드
-	 * @param bookDto 카카오 API에서 받은 책 정보
-	 * @return 기존 책 또는 새로 생성된 책
-	 */
 	public Book findOrCreateBook(BookDto bookDto) {
 		log.info("Finding or creating book: {}", bookDto.getTitle());
 
@@ -62,11 +57,6 @@ public class BookService {
 		return createNewBook(bookDto);
 	}
 
-	/**
-	 * 새로운 책을 생성하는 메서드
-	 * @param bookDto 책 정보
-	 * @return 생성된 책
-	 */
 	private Book createNewBook(BookDto bookDto) {
 		Book book = Book.builder()
 			.title(bookDto.getTitle())
@@ -84,12 +74,6 @@ public class BookService {
 		return savedBook;
 	}
 
-	/**
-	 * ISBN 문자열에서 첫 번째 ISBN을 추출하는 메서드
-	 * 예: "8968488703 9788968488702" → "8968488703"
-	 * @param isbn ISBN 문자열
-	 * @return 첫 번째 ISBN 또는 null
-	 */
 	private String extractFirstIsbn(String isbn) {
 		if (!StringUtils.hasText(isbn)) {
 			return null;
@@ -103,11 +87,6 @@ public class BookService {
 		return trimmedIsbn;
 	}
 
-	/**
-	 * 저자 리스트에서 첫 번째 저자를 가져오는 메서드
-	 * @param bookDto 책 정보
-	 * @return 첫 번째 저자 또는 빈 문자열
-	 */
 	private String getFirstAuthor(BookDto bookDto) {
 		if (bookDto.getAuthors() == null || bookDto.getAuthors().isEmpty()) {
 			return "";
@@ -115,22 +94,12 @@ public class BookService {
 		return bookDto.getAuthors().get(0);
 	}
 
-	/**
-	 * ID로 책 조회
-	 * @param bookId 책 ID
-	 * @return 책 정보
-	 */
 	@Transactional(readOnly = true)
 	public Book findBookById(Long bookId) {
 		return bookRepository.findById(bookId)
 			.orElseThrow(() -> new IllegalArgumentException("책을 찾을 수 없습니다: " + bookId));
 	}
 
-	/**
-	 * ISBN으로 책 조회
-	 * @param isbn ISBN
-	 * @return 책 정보
-	 */
 	@Transactional(readOnly = true)
 	public Optional<Book> findBookByIsbn(String isbn) {
 		String firstIsbn = extractFirstIsbn(isbn);

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -1,0 +1,162 @@
+package com.example.seolab.service;
+
+import com.example.seolab.dto.request.AddBookRequest;
+import com.example.seolab.dto.response.AddBookResponse;
+import com.example.seolab.dto.response.BookDto;
+import com.example.seolab.entity.Book;
+import com.example.seolab.entity.User;
+import com.example.seolab.entity.UserBook;
+import com.example.seolab.repository.UserBookRepository;
+import com.example.seolab.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class UserBookService {
+
+	private final UserBookRepository userBookRepository;
+	private final UserRepository userRepository;
+	private final BookService bookService;
+
+	public AddBookResponse addBookToUserLibrary(Long userId, AddBookRequest request) {
+		log.info("Adding book to user {} library: {}", userId, request.getBookInfo().getTitle());
+
+		// 1. 사용자 조회
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userId));
+
+		// 2. 카카오 API 정보를 BookDto로 변환
+		BookDto bookDto = convertToBookDto(request.getBookInfo());
+
+		// 3. 책을 찾거나 생성
+		Book book = bookService.findOrCreateBook(bookDto);
+
+		// 4. 이미 사용자가 이 책을 추가했는지 확인
+		Optional<UserBook> existingUserBook =
+			userBookRepository.findByUserUserIdAndBookBookId(userId, book.getBookId());
+
+		if (existingUserBook.isPresent()) {
+			throw new IllegalArgumentException("이미 내 서재에 추가된 책입니다.");
+		}
+
+		// 5. UserBook 생성
+		LocalDate startDate = request.getStartDate() != null ?
+			request.getStartDate() : LocalDate.now();
+
+		UserBook userBook = UserBook.builder()
+			.user(user)
+			.book(book)
+			.startDate(startDate)
+			.readingStatus(UserBook.ReadingStatus.READING)
+			.isFavorite(false)
+			.build();
+
+		UserBook savedUserBook = userBookRepository.save(userBook);
+		log.info("Successfully added book to user library. UserBook ID: {}", savedUserBook.getUserBookId());
+
+		// 6. Response 생성
+		return buildAddBookResponse(savedUserBook);
+	}
+
+	@Transactional(readOnly = true)
+	public List<UserBook> getReadingBooks(Long userId) {
+		return userBookRepository.findByUserUserIdAndReadingStatusOrderByCreatedAtDesc(
+			userId, UserBook.ReadingStatus.READING);
+	}
+
+	@Transactional(readOnly = true)
+	public List<UserBook> getFavoriteBooks(Long userId) {
+		return userBookRepository.findByUserUserIdAndIsFavoriteTrueOrderByCreatedAtDesc(userId);
+	}
+
+	public UserBook markBookAsCompleted(Long userId, Long userBookId) {
+		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
+		userBook.markAsCompleted();
+
+		log.info("User {} completed book: {}", userId, userBook.getBook().getTitle());
+		return userBookRepository.save(userBook);
+	}
+
+	public UserBook toggleFavorite(Long userId, Long userBookId) {
+		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
+		userBook.toggleFavorite();
+
+		log.info("User {} toggled favorite for book: {} ({})",
+			userId, userBook.getBook().getTitle(), userBook.getIsFavorite());
+		return userBookRepository.save(userBook);
+	}
+
+	private UserBook findUserBookByIdAndUserId(Long userBookId, Long userId) {
+		return userBookRepository.findById(userBookId)
+			.filter(ub -> ub.getUser().getUserId().equals(userId))
+			.orElseThrow(() -> new IllegalArgumentException("접근할 수 없는 책입니다."));
+	}
+
+	private BookDto convertToBookDto(AddBookRequest.BookInfo bookInfo) {
+		LocalDate publishedDate = parsePublishedDate(bookInfo.getPublishedDate());
+
+		return BookDto.builder()
+			.title(bookInfo.getTitle())
+			.contents(bookInfo.getContents())
+			.isbn(bookInfo.getIsbn())
+			.publishedDate(publishedDate)
+			.authors(bookInfo.getAuthors())
+			.publisher(bookInfo.getPublisher())
+			.translators(bookInfo.getTranslators())
+			.thumbnail(bookInfo.getThumbnail())
+			.build();
+	}
+
+	private LocalDate parsePublishedDate(String dateString) {
+		if (dateString == null || dateString.isEmpty()) {
+			return null;
+		}
+
+		try {
+			// "2016-08-16T00:00:00.000+09:00" 형태에서 날짜 부분만 추출
+			if (dateString.contains("T")) {
+				dateString = dateString.substring(0, 10);
+			}
+			return LocalDate.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE);
+		} catch (DateTimeParseException e) {
+			log.warn("Failed to parse published date: {}", dateString);
+			return null;
+		}
+	}
+
+	private AddBookResponse buildAddBookResponse(UserBook userBook) {
+		Book book = userBook.getBook();
+
+		AddBookResponse.BookDetail bookDetail = AddBookResponse.BookDetail.builder()
+			.bookId(book.getBookId())
+			.title(book.getTitle())
+			.author(book.getAuthor())
+			.publisher(book.getPublisher())
+			.isbn(book.getIsbn())
+			.description(book.getDescription())
+			.coverImage(book.getCoverImage())
+			.publishedDate(book.getPublishedDate())
+			.build();
+
+		return AddBookResponse.builder()
+			.userBookId(userBook.getUserBookId())
+			.book(bookDetail)
+			.startDate(userBook.getStartDate())
+			.readingStatus(userBook.getReadingStatus().getValue())
+			.isFavorite(userBook.getIsFavorite())
+			.createdAt(userBook.getCreatedAt())
+			.message("책이 성공적으로 추가되었습니다.")
+			.build();
+	}
+}


### PR DESCRIPTION
## 작업 내용
사용자가 검색한 책을 내 서랍에 추가하고 관리할 수 있는 기능을 구현했습니다.

## 구현 기능
- **책 저장 시스템**
  - Book Entity (auto-increment ID, unique 제약)
  - ISBN 우선 검색 + title/author/publisher fallback 로직
  - 중복 방지를 위한 unique 제약

- **내 서랍 관리**
  - 책 추가 기능
  - 읽고 있는 책 / 즐겨찾기 책 목록 조회
  - 읽기 완료 상태 토글
  - 즐겨찾기 토글

- **API 엔드포인트**
  - `POST /api/books/add` - 내 서랍에 책 추가
  - `GET /api/books/reading` - 읽고 있는 책 목록
  - `GET /api/books/favorites` - 즐겨찾기 책 목록
  - `PATCH /api/books/{id}/complete` - 읽기 완료 토글
  - `PATCH /api/books/{id}/favorite` - 즐겨찾기 토글

- **DTO 설계**
  - UserBookResponse DTO로 Lazy Loading 문제 해결
  - 명확한 API 응답 구조 설계

## 주요 변경사항
- **Entity 구조 최적화**
  - start_date 필드 제거하여 created_at으로 통합
  - toggleReadingStatus(), toggleFavorite() 토글 방식 구현
  - getStartDate() 메서드로 created_at에서 날짜 추출

- **Service Layer**
  - BookService: 중복 체크 및 책 생성 로직
  - UserBookService: 사용자 서재 관리 로직
  - DTO 변환 로직으로 JSON 직렬화 문제 해결

- **Repository**
  - BookRepository: ISBN, title+author+publisher 검색
  - UserBookRepository: 사용자별 책 조회 최적화