### PR TITLE
fix: books 관련 api 구조 개선

### DIFF
--- a/src/main/java/com/example/seolab/controller/BookController.java
+++ b/src/main/java/com/example/seolab/controller/BookController.java
@@ -39,20 +39,16 @@ public class BookController {
 		return ResponseEntity.status(HttpStatus.CREATED).body(response);
 	}
 
-	@GetMapping("/reading")
-	public ResponseEntity<List<UserBookResponse>> getReadingBooks(Authentication authentication) {
+	@GetMapping
+	public ResponseEntity<List<UserBookResponse>> getUserBooks(
+		@RequestParam(required = false) Boolean favorite,
+		@RequestParam(required = false) Boolean reading,
+		Authentication authentication) {
+
 		Long userId = getUserIdFromAuthentication(authentication);
-		List<UserBookResponse> readingBooks = userBookService.getReadingBooks(userId);
+		List<UserBookResponse> books = userBookService.getUserBooks(userId, favorite, reading);
 
-		return ResponseEntity.ok(readingBooks);
-	}
-
-	@GetMapping("/favorites")
-	public ResponseEntity<List<UserBookResponse>> getFavoriteBooks(Authentication authentication) {
-		Long userId = getUserIdFromAuthentication(authentication);
-		List<UserBookResponse> favoriteBooks = userBookService.getFavoriteBooks(userId);
-
-		return ResponseEntity.ok(favoriteBooks);
+		return ResponseEntity.ok(books);
 	}
 
 	@PatchMapping("/{userBookId}/complete")

--- a/src/main/java/com/example/seolab/controller/BookController.java
+++ b/src/main/java/com/example/seolab/controller/BookController.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/books")
@@ -23,7 +24,7 @@ public class BookController {
 
 	private final UserBookService userBookService;
 
-	@PostMapping // "/add" 제거
+	@PostMapping
 	public ResponseEntity<AddBookResponse> addBookToLibrary(
 		@Valid @RequestBody AddBookRequest request,
 		Authentication authentication) {
@@ -53,7 +54,7 @@ public class BookController {
 
 	@PatchMapping("/{userBookId}/complete")
 	public ResponseEntity<UserBookResponse> markBookAsCompleted(
-		@PathVariable Long userBookId,
+		@PathVariable UUID userBookId,
 		Authentication authentication) {
 
 		Long userId = getUserIdFromAuthentication(authentication);
@@ -64,7 +65,7 @@ public class BookController {
 
 	@PatchMapping("/{userBookId}/favorite")
 	public ResponseEntity<UserBookResponse> toggleFavorite(
-		@PathVariable Long userBookId,
+		@PathVariable UUID userBookId,
 		Authentication authentication) {
 
 		Long userId = getUserIdFromAuthentication(authentication);

--- a/src/main/java/com/example/seolab/controller/BookController.java
+++ b/src/main/java/com/example/seolab/controller/BookController.java
@@ -23,13 +23,13 @@ public class BookController {
 
 	private final UserBookService userBookService;
 
-	@PostMapping
+	@PostMapping // "/add" 제거
 	public ResponseEntity<AddBookResponse> addBookToLibrary(
 		@Valid @RequestBody AddBookRequest request,
 		Authentication authentication) {
 
 		String userEmail = authentication.getName();
-		log.info("User {} is adding book: {}", userEmail, request.getBookInfo().getTitle());
+		log.info("User {} is adding book: {}", userEmail, request.getTitle());
 
 		// Authentication에서 실제 사용자 ID 추출
 		Long userId = getUserIdFromAuthentication(authentication);

--- a/src/main/java/com/example/seolab/controller/BookController.java
+++ b/src/main/java/com/example/seolab/controller/BookController.java
@@ -23,7 +23,7 @@ public class BookController {
 
 	private final UserBookService userBookService;
 
-	@PostMapping("/add")
+	@PostMapping
 	public ResponseEntity<AddBookResponse> addBookToLibrary(
 		@Valid @RequestBody AddBookRequest request,
 		Authentication authentication) {

--- a/src/main/java/com/example/seolab/dto/request/AddBookRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/AddBookRequest.java
@@ -1,38 +1,27 @@
 package com.example.seolab.dto.request;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class AddBookRequest {
-	@NotNull(message = "책 정보는 필수입니다.")
-	@Valid
-	private BookInfo bookInfo;
 
-	@Getter
-	@Setter
-	@NoArgsConstructor
-	@AllArgsConstructor
-	public static class BookInfo {
+	@NotNull(message = "책 제목은 필수입니다.")
+	private String title;
 
-		@NotNull(message = "책 제목은 필수입니다.")
-		private String title;
-
-		private String contents;
-		private String isbn;
-		private String publishedDate; // ISO 형태 문자열
-		private java.util.List<String> authors;
-		private String publisher;
-		private java.util.List<String> translators;
-		private String thumbnail;
-	}
+	private String contents;
+	private String isbn;
+	private String publishedDate;
+	private List<String> authors;
+	private String publisher;
+	private List<String> translators;
+	private String thumbnail;
 }

--- a/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
@@ -20,8 +20,8 @@ public class AddBookResponse {
 	private Long userBookId;
 	private BookDetail book;
 	private LocalDate startDate;
-	private String readingStatus;
 	private Boolean isFavorite;
+	private Boolean isReading;
 	private LocalDateTime createdAt;
 	private String message;
 

--- a/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -17,7 +18,7 @@ import java.util.List;
 @Builder
 public class AddBookResponse {
 
-	private Long userBookId;
+	private UUID userBookId;
 	private BookDetail book;
 	private LocalDate startDate;
 	private Boolean isReading;

--- a/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
@@ -20,8 +20,8 @@ public class AddBookResponse {
 	private Long userBookId;
 	private BookDetail book;
 	private LocalDate startDate;
-	private Boolean isFavorite;
 	private Boolean isReading;
+	private Boolean isFavorite;
 	private LocalDateTime createdAt;
 	private String message;
 
@@ -33,11 +33,12 @@ public class AddBookResponse {
 	public static class BookDetail {
 		private Long bookId;
 		private String title;
-		private String author;
-		private String publisher;
+		private String contents;
 		private String isbn;
-		private String description;
-		private String coverImage;
 		private LocalDate publishedDate;
+		private List<String> authors;
+		private String publisher;
+		private List<String> translators;
+		private String thumbnail;
 	}
 }

--- a/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -32,11 +33,12 @@ public class UserBookResponse {
 	public static class BookInfo {
 		private Long bookId;
 		private String title;
-		private String author;
-		private String publisher;
+		private String contents;
 		private String isbn;
-		private String description;
-		private String coverImage;
 		private LocalDate publishedDate;
+		private List<String> authors;
+		private String publisher;
+		private List<String> translators;
+		private String thumbnail;
 	}
 }

--- a/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
@@ -20,7 +20,7 @@ public class UserBookResponse {
 	private LocalDate startDate;
 	private LocalDate endDate;
 	private Boolean isFavorite;
-	private String readingStatus;
+	private Boolean isReading;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
 

--- a/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -16,7 +17,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class UserBookResponse {
-	private Long userBookId;
+	private UUID userBookId;
 	private BookInfo book;
 	private LocalDate startDate;
 	private LocalDate endDate;

--- a/src/main/java/com/example/seolab/entity/Book.java
+++ b/src/main/java/com/example/seolab/entity/Book.java
@@ -6,9 +6,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Table(
@@ -16,7 +19,7 @@ import java.time.LocalDateTime;
 	uniqueConstraints = {
 		@UniqueConstraint(
 			name = "unique_book",
-			columnNames = {"title", "author", "publisher"}
+			columnNames = {"title", "authors", "publisher"}
 		)
 	}
 )
@@ -35,21 +38,25 @@ public class Book {
 	@Column(nullable = false)
 	private String title;
 
-	@Column(nullable = false)
-	private String author;
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(nullable = false, columnDefinition = "JSON")
+	private List<String> authors;  // JSON 배열로 저장
 
 	private String publisher;
 
 	private String isbn;
 
 	@Column(columnDefinition = "TEXT")
-	private String description;
+	private String contents;
 
-	@Column(name = "cover_image")
-	private String coverImage;
+	private String thumbnail;
 
 	@Column(name = "published_date")
 	private LocalDate publishedDate;
+
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(columnDefinition = "JSON")
+	private List<String> translators;  // JSON 배열로 저장
 
 	@Column(name = "created_at")
 	private LocalDateTime createdAt;
@@ -57,5 +64,10 @@ public class Book {
 	@PrePersist
 	protected void onCreate() {
 		createdAt = LocalDateTime.now();
+	}
+
+	// 편의 메소드: 첫 번째 저자 반환 (기존 로직 호환용)
+	public String getFirstAuthor() {
+		return authors != null && !authors.isEmpty() ? authors.get(0) : "";
 	}
 }

--- a/src/main/java/com/example/seolab/entity/UserBook.java
+++ b/src/main/java/com/example/seolab/entity/UserBook.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Table(
@@ -28,9 +29,9 @@ import java.time.LocalDateTime;
 public class UserBook {
 
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "user_book_id")
-	private Long userBookId;
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "user_book_id", columnDefinition = "BINARY(16)")
+	private UUID userBookId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", nullable = false)
@@ -49,7 +50,7 @@ public class UserBook {
 
 	@Column(name = "is_reading")
 	@Builder.Default
-	private Boolean isReading = true;  // TRUE: 읽는 중, FALSE: 완독
+	private Boolean isReading = true;
 
 	@Column(name = "created_at")
 	private LocalDateTime createdAt;
@@ -74,11 +75,9 @@ public class UserBook {
 
 	public void toggleReading() {
 		if (this.isReading) {
-			// 읽는 중 → 완독
 			this.isReading = false;
 			this.endDate = LocalDate.now();
 		} else {
-			// 완독 → 읽는 중
 			this.isReading = true;
 			this.endDate = null; // 완독일 제거
 		}
@@ -88,7 +87,6 @@ public class UserBook {
 		this.isFavorite = !this.isFavorite;
 	}
 
-	// 편의 메소드들
 	public boolean isCurrentlyReading() {
 		return this.isReading;
 	}

--- a/src/main/java/com/example/seolab/entity/UserBook.java
+++ b/src/main/java/com/example/seolab/entity/UserBook.java
@@ -47,10 +47,9 @@ public class UserBook {
 	@Builder.Default
 	private Boolean isFavorite = false;
 
-	@Enumerated(EnumType.STRING)
-	@Column(name = "reading_status")
+	@Column(name = "is_reading")
 	@Builder.Default
-	private ReadingStatus readingStatus = ReadingStatus.READING;
+	private Boolean isReading = true;  // TRUE: 읽는 중, FALSE: 완독
 
 	@Column(name = "created_at")
 	private LocalDateTime createdAt;
@@ -69,33 +68,18 @@ public class UserBook {
 		updatedAt = LocalDateTime.now();
 	}
 
-	public enum ReadingStatus {
-		READING("reading"),
-		COMPLETED("completed");
-
-		private final String value;
-
-		ReadingStatus(String value) {
-			this.value = value;
-		}
-
-		public String getValue() {
-			return value;
-		}
-	}
-
 	public LocalDate getStartDate() {
 		return createdAt != null ? createdAt.toLocalDate() : null;
 	}
 
-	public void toggleReadingStatus() {
-		if (this.readingStatus == ReadingStatus.READING) {
-			// 읽는중 → 완료
-			this.readingStatus = ReadingStatus.COMPLETED;
+	public void toggleReading() {
+		if (this.isReading) {
+			// 읽는 중 → 완독
+			this.isReading = false;
 			this.endDate = LocalDate.now();
 		} else {
-			// 완료 → 읽는중
-			this.readingStatus = ReadingStatus.READING;
+			// 완독 → 읽는 중
+			this.isReading = true;
 			this.endDate = null; // 완독일 제거
 		}
 	}
@@ -104,11 +88,12 @@ public class UserBook {
 		this.isFavorite = !this.isFavorite;
 	}
 
-	public boolean isReading() {
-		return this.readingStatus == ReadingStatus.READING;
+	// 편의 메소드들
+	public boolean isCurrentlyReading() {
+		return this.isReading;
 	}
 
 	public boolean isCompleted() {
-		return this.readingStatus == ReadingStatus.COMPLETED;
+		return !this.isReading;
 	}
 }

--- a/src/main/java/com/example/seolab/exception/DuplicateBookException.java
+++ b/src/main/java/com/example/seolab/exception/DuplicateBookException.java
@@ -1,0 +1,7 @@
+package com.example.seolab.exception;
+
+public class DuplicateBookException extends RuntimeException {
+	public DuplicateBookException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
@@ -54,6 +54,14 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
 	}
 
+	@ExceptionHandler(DuplicateBookException.class)
+	public ResponseEntity<Map<String, String>> handleDuplicateBookException(
+		DuplicateBookException ex) {
+		Map<String, String> error = new HashMap<>();
+		error.put("message", ex.getMessage());
+		return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
+	}
+
 	// 이메일 중복 오류를 409 Conflict로 처리
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<Map<String, String>> handleIllegalArgumentException(

--- a/src/main/java/com/example/seolab/repository/UserBookRepository.java
+++ b/src/main/java/com/example/seolab/repository/UserBookRepository.java
@@ -8,9 +8,10 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
-public interface UserBookRepository extends JpaRepository<UserBook, Long> {
+public interface UserBookRepository extends JpaRepository<UserBook, UUID> {
 
 	Optional<UserBook> findByUserUserIdAndBookBookId(Long userId, Long bookId);
 
@@ -22,7 +23,6 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
 
 	List<UserBook> findByUserUserIdAndIsFavoriteTrueOrderByCreatedAtDesc(Long userId);
 
-	// 즐겨찾기이면서 특정 읽기 상태인 책들
 	List<UserBook> findByUserUserIdAndIsFavoriteTrueAndIsReadingOrderByCreatedAtDesc(
 		Long userId, Boolean isReading);
 

--- a/src/main/java/com/example/seolab/repository/UserBookRepository.java
+++ b/src/main/java/com/example/seolab/repository/UserBookRepository.java
@@ -23,6 +23,8 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
 
 	List<UserBook> findByUserUserIdAndIsFavoriteTrueOrderByCreatedAtDesc(Long userId);
 
+	List<UserBook> findByUserUserIdAndIsFavoriteTrueAndReadingStatusOrderByCreatedAtDesc(Long userId, ReadingStatus readingStatus);
+
 	long countByUserUserIdAndReadingStatus(Long userId, ReadingStatus readingStatus);
 
 	Optional<UserBook> findTopByUserUserIdOrderByCreatedAtDesc(Long userId);

--- a/src/main/java/com/example/seolab/repository/UserBookRepository.java
+++ b/src/main/java/com/example/seolab/repository/UserBookRepository.java
@@ -22,7 +22,9 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
 
 	List<UserBook> findByUserUserIdAndIsFavoriteTrueOrderByCreatedAtDesc(Long userId);
 
-	List<UserBook> findByUserUserIdAndIsFavoriteTrueAndIsReadingOrderByCreatedAtDesc(Long userId, Boolean isReading);
+	// 즐겨찾기이면서 특정 읽기 상태인 책들
+	List<UserBook> findByUserUserIdAndIsFavoriteTrueAndIsReadingOrderByCreatedAtDesc(
+		Long userId, Boolean isReading);
 
 	long countByUserUserIdAndIsReading(Long userId, Boolean isReading);
 

--- a/src/main/java/com/example/seolab/repository/UserBookRepository.java
+++ b/src/main/java/com/example/seolab/repository/UserBookRepository.java
@@ -1,7 +1,6 @@
 package com.example.seolab.repository;
 
 import com.example.seolab.entity.UserBook;
-import com.example.seolab.entity.UserBook.ReadingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,20 +18,20 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long> {
 
 	List<UserBook> findByUserUserIdOrderByCreatedAtDesc(Long userId);
 
-	List<UserBook> findByUserUserIdAndReadingStatusOrderByCreatedAtDesc(Long userId, ReadingStatus readingStatus);
+	List<UserBook> findByUserUserIdAndIsReadingOrderByCreatedAtDesc(Long userId, Boolean isReading);
 
 	List<UserBook> findByUserUserIdAndIsFavoriteTrueOrderByCreatedAtDesc(Long userId);
 
-	List<UserBook> findByUserUserIdAndIsFavoriteTrueAndReadingStatusOrderByCreatedAtDesc(Long userId, ReadingStatus readingStatus);
+	List<UserBook> findByUserUserIdAndIsFavoriteTrueAndIsReadingOrderByCreatedAtDesc(Long userId, Boolean isReading);
 
-	long countByUserUserIdAndReadingStatus(Long userId, ReadingStatus readingStatus);
+	long countByUserUserIdAndIsReading(Long userId, Boolean isReading);
 
 	Optional<UserBook> findTopByUserUserIdOrderByCreatedAtDesc(Long userId);
 
 	@Query("SELECT ub FROM UserBook ub " +
 		"WHERE ub.user.userId = :userId " +
-		"AND ub.readingStatus = :status " +
+		"AND ub.isReading = :isReading " +
 		"ORDER BY ub.updatedAt DESC")
-	List<UserBook> findRecentReadingBooks(@Param("userId") Long userId,
-		@Param("status") ReadingStatus status);
+	List<UserBook> findRecentBooks(@Param("userId") Long userId,
+		@Param("isReading") Boolean isReading);
 }

--- a/src/main/java/com/example/seolab/service/BookService.java
+++ b/src/main/java/com/example/seolab/service/BookService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -60,12 +60,13 @@ public class BookService {
 	private Book createNewBook(BookDto bookDto) {
 		Book book = Book.builder()
 			.title(bookDto.getTitle())
-			.author(getFirstAuthor(bookDto))
+			.authors(bookDto.getAuthors() != null ? bookDto.getAuthors() : List.of())  // JSON 배열
 			.publisher(bookDto.getPublisher())
 			.isbn(extractFirstIsbn(bookDto.getIsbn()))
-			.description(bookDto.getContents())
-			.coverImage(bookDto.getThumbnail())
+			.contents(bookDto.getContents())
+			.thumbnail(bookDto.getThumbnail())
 			.publishedDate(bookDto.getPublishedDate())
+			.translators(bookDto.getTranslators() != null ? bookDto.getTranslators() : List.of())  // JSON 배열
 			.build();
 
 		Book savedBook = bookRepository.save(book);

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -51,7 +51,7 @@ public class UserBookService {
 		UserBook userBook = UserBook.builder()
 			.user(user)
 			.book(book)
-			.isReading(true)  // 기본적으로 읽는 중 상태
+			.isReading(true)
 			.isFavorite(false)
 			.build();
 
@@ -156,12 +156,13 @@ public class UserBookService {
 		AddBookResponse.BookDetail bookDetail = AddBookResponse.BookDetail.builder()
 			.bookId(book.getBookId())
 			.title(book.getTitle())
-			.author(book.getAuthor())
-			.publisher(book.getPublisher())
+			.contents(book.getContents())
 			.isbn(book.getIsbn())
-			.description(book.getDescription())
-			.coverImage(book.getCoverImage())
 			.publishedDate(book.getPublishedDate())
+			.authors(book.getAuthors())
+			.publisher(book.getPublisher())
+			.translators(book.getTranslators())
+			.thumbnail(book.getThumbnail())
 			.build();
 
 		return AddBookResponse.builder()
@@ -181,12 +182,13 @@ public class UserBookService {
 		UserBookResponse.BookInfo bookInfo = UserBookResponse.BookInfo.builder()
 			.bookId(book.getBookId())
 			.title(book.getTitle())
-			.author(book.getAuthor())
-			.publisher(book.getPublisher())
+			.contents(book.getContents())
 			.isbn(book.getIsbn())
-			.description(book.getDescription())
-			.coverImage(book.getCoverImage())
 			.publishedDate(book.getPublishedDate())
+			.authors(book.getAuthors())
+			.publisher(book.getPublisher())
+			.translators(book.getTranslators())
+			.thumbnail(book.getThumbnail())
 			.build();
 
 		return UserBookResponse.builder()

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -7,6 +7,7 @@ import com.example.seolab.dto.response.UserBookResponse;
 import com.example.seolab.entity.Book;
 import com.example.seolab.entity.User;
 import com.example.seolab.entity.UserBook;
+import com.example.seolab.exception.DuplicateBookException;
 import com.example.seolab.repository.UserBookRepository;
 import com.example.seolab.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,7 @@ public class UserBookService {
 			userBookRepository.findByUserUserIdAndBookBookId(userId, book.getBookId());
 
 		if (existingUserBook.isPresent()) {
-			throw new IllegalArgumentException("이미 내 서재에 추가된 책입니다.");
+			throw new DuplicateBookException("이미 내 서재에 추가된 책입니다.");
 		}
 
 		UserBook userBook = UserBook.builder()

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -32,12 +32,12 @@ public class UserBookService {
 	private final BookService bookService;
 
 	public AddBookResponse addBookToUserLibrary(Long userId, AddBookRequest request) {
-		log.info("Adding book to user {} library: {}", userId, request.getBookInfo().getTitle());
+		log.info("Adding book to user {} library: {}", userId, request.getTitle());
 
 		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다: " + userId));
 
-		BookDto bookDto = convertToBookDto(request.getBookInfo());
+		BookDto bookDto = convertToBookDto(request);
 
 		Book book = bookService.findOrCreateBook(bookDto);
 
@@ -90,7 +90,7 @@ public class UserBookService {
 		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
 
 		boolean beforeReading = userBook.getIsReading();
-		userBook.toggleReading(); // 읽는 중 ↔ 완독 토글
+		userBook.toggleReading();
 		boolean afterReading = userBook.getIsReading();
 
 		log.info("User {} toggled reading status for book: {} ({} → {})",
@@ -119,18 +119,18 @@ public class UserBookService {
 			.orElseThrow(() -> new IllegalArgumentException("접근할 수 없는 책입니다."));
 	}
 
-	private BookDto convertToBookDto(AddBookRequest.BookInfo bookInfo) {
-		LocalDate publishedDate = parsePublishedDate(bookInfo.getPublishedDate());
+	private BookDto convertToBookDto(AddBookRequest request) {
+		LocalDate publishedDate = parsePublishedDate(request.getPublishedDate());
 
 		return BookDto.builder()
-			.title(bookInfo.getTitle())
-			.contents(bookInfo.getContents())
-			.isbn(bookInfo.getIsbn())
+			.title(request.getTitle())
+			.contents(request.getContents())
+			.isbn(request.getIsbn())
 			.publishedDate(publishedDate)
-			.authors(bookInfo.getAuthors())
-			.publisher(bookInfo.getPublisher())
-			.translators(bookInfo.getTranslators())
-			.thumbnail(bookInfo.getThumbnail())
+			.authors(request.getAuthors())
+			.publisher(request.getPublisher())
+			.translators(request.getTranslators())
+			.thumbnail(request.getThumbnail())
 			.build();
 	}
 
@@ -168,7 +168,7 @@ public class UserBookService {
 			.userBookId(userBook.getUserBookId())
 			.book(bookDetail)
 			.startDate(userBook.getStartDate())
-			.isReading(userBook.getIsReading())  // readingStatus → isReading
+			.isReading(userBook.getIsReading())
 			.isFavorite(userBook.getIsFavorite())
 			.createdAt(userBook.getCreatedAt())
 			.message("책이 성공적으로 추가되었습니다.")
@@ -195,7 +195,7 @@ public class UserBookService {
 			.startDate(userBook.getStartDate())
 			.endDate(userBook.getEndDate())
 			.isFavorite(userBook.getIsFavorite())
-			.isReading(userBook.getIsReading())  // readingStatus → isReading
+			.isReading(userBook.getIsReading())
 			.createdAt(userBook.getCreatedAt())
 			.updatedAt(userBook.getUpdatedAt())
 			.build();

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -20,6 +20,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -51,7 +52,7 @@ public class UserBookService {
 		UserBook userBook = UserBook.builder()
 			.user(user)
 			.book(book)
-			.isReading(true)
+			.isReading(true)  // 기본적으로 읽는 중 상태
 			.isFavorite(false)
 			.build();
 
@@ -86,11 +87,11 @@ public class UserBookService {
 			.toList();
 	}
 
-	public UserBookResponse markBookAsCompleted(Long userId, Long userBookId) {
+	public UserBookResponse markBookAsCompleted(Long userId, UUID userBookId) {
 		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
 
 		boolean beforeReading = userBook.getIsReading();
-		userBook.toggleReading();
+		userBook.toggleReading(); // 읽는 중 ↔ 완독 토글
 		boolean afterReading = userBook.getIsReading();
 
 		log.info("User {} toggled reading status for book: {} ({} → {})",
@@ -102,7 +103,7 @@ public class UserBookService {
 		return convertToUserBookResponse(savedUserBook);
 	}
 
-	public UserBookResponse toggleFavorite(Long userId, Long userBookId) {
+	public UserBookResponse toggleFavorite(Long userId, UUID userBookId) {
 		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
 		userBook.toggleFavorite();
 
@@ -113,7 +114,7 @@ public class UserBookService {
 		return convertToUserBookResponse(savedUserBook);
 	}
 
-	private UserBook findUserBookByIdAndUserId(Long userBookId, Long userId) {
+	private UserBook findUserBookByIdAndUserId(UUID userBookId, Long userId) {
 		return userBookRepository.findById(userBookId)
 			.filter(ub -> ub.getUser().getUserId().equals(userId))
 			.orElseThrow(() -> new IllegalArgumentException("접근할 수 없는 책입니다."));


### PR DESCRIPTION
## 작업 내용
API 구조를 개선하고 UUID 식별자를 적용했습니다.

## 구현 기능
- **API 엔드포인트 통합**
  - `POST /api/books` - 책 추가 (기존 `/add` 제거)
  - `GET /api/books` - 쿼리 파라미터 기반 책 목록 조회
  - `PATCH /api/books/{userBookId}/complete` - 읽기 상태 토글
  - `PATCH /api/books/{userBookId}/favorite` - 즐겨찾기 토글

- **UUID 기반 식별자 도입**
  - UserBook ID를 Auto Increment → Binary UUID로 변경

- **데이터 구조 개선**
  - `readingStatus` enum → `isReading` boolean으로 단순화
  - JSON 컬럼 활용으로 다중 저자/번역자 지원
  - 카카오 API와 일관된 응답 필드 순서 적용

## 주요 변경사항
**API 구조 통합:**
- 별도 엔드포인트를 쿼리 파라미터로 통합
- `GET /api/books?reading=true&favorite=true` 형태로 필터링

**데이터베이스 스키마:**
- `user_book_id`: `BIGINT AUTO_INCREMENT` → `BINARY(16) UUID`
- `reading_status`: `ENUM` → `is_reading BOOLEAN`
- `authors`, `translators`: `VARCHAR` → `JSON` 배열

**Request/Response 개선:**
- 중복 책 추가 시 409 Conflict 응답
- Request Body 플랫 구조 적용 (`bookInfo` 제거)
- 카카오 API와 일관된 필드명 및 순서 적용

## 참고사항
- Binary UUID 사용으로 API URL이 `/api/books/{uuid}` 형태로 변경
- 프론트엔드에서 userBookId 타입 변경 대응 필요 (number → string)