### PR TITLE
fix: api/books api 응답 최적화 및 개별 책 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/seolab/controller/BookController.java
+++ b/src/main/java/com/example/seolab/controller/BookController.java
@@ -74,6 +74,17 @@ public class BookController {
 		return ResponseEntity.ok(toggledBook);
 	}
 
+	@GetMapping("/{userBookId}")
+	public ResponseEntity<UserBookResponse> getUserBook(
+		@PathVariable UUID userBookId,
+		Authentication authentication) {
+
+		Long userId = getUserIdFromAuthentication(authentication);
+		UserBookResponse userBook = userBookService.getUserBook(userId, userBookId);
+
+		return ResponseEntity.ok(userBook);
+	}
+
 	private Long getUserIdFromAuthentication(Authentication authentication) {
 		// Spring Security에서 인증된 User 객체 가져오기
 		User user = (User) authentication.getPrincipal();

--- a/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
@@ -6,9 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -17,27 +14,6 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 public class AddBookResponse {
-
 	private UUID userBookId;
-	private BookDetail book;
-	private LocalDate startDate;
-	private Boolean isReading;
-	private Boolean isFavorite;
-	private LocalDateTime createdAt;
 	private String message;
-
-	@Getter
-	@Setter
-	@NoArgsConstructor
-	@AllArgsConstructor
-	@Builder
-	public static class BookDetail {
-		private String title;
-		private String isbn;
-		private LocalDate publishedDate;
-		private List<String> authors;
-		private String publisher;
-		private List<String> translators;
-		private String thumbnail;
-	}
 }

--- a/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/AddBookResponse.java
@@ -32,9 +32,7 @@ public class AddBookResponse {
 	@AllArgsConstructor
 	@Builder
 	public static class BookDetail {
-		private Long bookId;
 		private String title;
-		private String contents;
 		private String isbn;
 		private LocalDate publishedDate;
 		private List<String> authors;

--- a/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
@@ -32,9 +32,7 @@ public class UserBookResponse {
 	@AllArgsConstructor
 	@Builder
 	public static class BookInfo {
-		private Long bookId;
 		private String title;
-		private String contents;
 		private String isbn;
 		private LocalDate publishedDate;
 		private List<String> authors;

--- a/src/main/java/com/example/seolab/exception/DuplicateBookException.java
+++ b/src/main/java/com/example/seolab/exception/DuplicateBookException.java
@@ -1,7 +1,16 @@
 package com.example.seolab.exception;
 
+import java.util.UUID;
+
 public class DuplicateBookException extends RuntimeException {
-	public DuplicateBookException(String message) {
+	private final UUID userBookId;
+
+	public DuplicateBookException(String message, UUID userBookId) {
 		super(message);
+		this.userBookId = userBookId;
+	}
+
+	public UUID getUserBookId() {
+		return userBookId;
 	}
 }

--- a/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
@@ -58,8 +58,8 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<Map<String, Object>> handleDuplicateBookException(
 		DuplicateBookException ex) {
 		Map<String, Object> error = new HashMap<>();
-		error.put("message", ex.getMessage());
 		error.put("userBookId", ex.getUserBookId());
+		error.put("message", ex.getMessage());
 		return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
 	}
 

--- a/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
@@ -55,10 +55,11 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(DuplicateBookException.class)
-	public ResponseEntity<Map<String, String>> handleDuplicateBookException(
+	public ResponseEntity<Map<String, Object>> handleDuplicateBookException(
 		DuplicateBookException ex) {
-		Map<String, String> error = new HashMap<>();
+		Map<String, Object> error = new HashMap<>();
 		error.put("message", ex.getMessage());
+		error.put("userBookId", ex.getUserBookId());
 		return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
 	}
 

--- a/src/main/java/com/example/seolab/repository/UserBookRepository.java
+++ b/src/main/java/com/example/seolab/repository/UserBookRepository.java
@@ -17,13 +17,14 @@ public interface UserBookRepository extends JpaRepository<UserBook, UUID> {
 
 	boolean existsByUserUserIdAndBookBookId(Long userId, Long bookId);
 
-	List<UserBook> findByUserUserIdOrderByCreatedAtDesc(Long userId);
+	// updatedAt 기준으로 변경
+	List<UserBook> findByUserUserIdOrderByUpdatedAtDesc(Long userId);
 
-	List<UserBook> findByUserUserIdAndIsReadingOrderByCreatedAtDesc(Long userId, Boolean isReading);
+	List<UserBook> findByUserUserIdAndIsReadingOrderByUpdatedAtDesc(Long userId, Boolean isReading);
 
-	List<UserBook> findByUserUserIdAndIsFavoriteTrueOrderByCreatedAtDesc(Long userId);
+	List<UserBook> findByUserUserIdAndIsFavoriteTrueOrderByUpdatedAtDesc(Long userId);
 
-	List<UserBook> findByUserUserIdAndIsFavoriteTrueAndIsReadingOrderByCreatedAtDesc(
+	List<UserBook> findByUserUserIdAndIsFavoriteTrueAndIsReadingOrderByUpdatedAtDesc(
 		Long userId, Boolean isReading);
 
 	long countByUserUserIdAndIsReading(Long userId, Boolean isReading);

--- a/src/main/java/com/example/seolab/service/BookService.java
+++ b/src/main/java/com/example/seolab/service/BookService.java
@@ -31,9 +31,12 @@ public class BookService {
 				log.info("Found existing book by ISBN: {}", firstIsbn);
 				return existingByIsbn.get();
 			}
+			// ISBN이 있지만 찾지 못한 경우, 바로 새 책 생성
+			log.info("No existing book found with ISBN: {}, creating new book", firstIsbn);
+			return createNewBook(bookDto);
 		}
 
-		// 2. title + author + publisher 조합으로 찾기
+		// 2. ISBN이 없는 경우에만 title + author + publisher 조합으로 찾기
 		String firstAuthor = getFirstAuthor(bookDto);
 		if (StringUtils.hasText(bookDto.getTitle()) &&
 			StringUtils.hasText(firstAuthor) &&

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -46,7 +46,9 @@ public class UserBookService {
 			userBookRepository.findByUserUserIdAndBookBookId(userId, book.getBookId());
 
 		if (existingUserBook.isPresent()) {
-			throw new DuplicateBookException("이미 내 서재에 추가된 책입니다.");
+			UserBook userBook = existingUserBook.get();
+			UUID userBookId = userBook.getUserBookId();
+			throw new DuplicateBookException("이미 내 서재에 추가된 책입니다.", userBookId);
 		}
 
 		UserBook userBook = UserBook.builder()

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -54,14 +54,17 @@ public class UserBookService {
 		UserBook userBook = UserBook.builder()
 			.user(user)
 			.book(book)
-			.isReading(true)  // 기본적으로 읽는 중 상태
+			.isReading(true)
 			.isFavorite(false)
 			.build();
 
 		UserBook savedUserBook = userBookRepository.save(userBook);
 		log.info("Successfully added book to user library. UserBook ID: {}", savedUserBook.getUserBookId());
 
-		return buildAddBookResponse(savedUserBook);
+		return AddBookResponse.builder()
+			.userBookId(savedUserBook.getUserBookId())
+			.message("책이 성공적으로 추가되었습니다.")
+			.build();
 	}
 
 	@Transactional(readOnly = true)
@@ -157,30 +160,6 @@ public class UserBookService {
 			log.warn("Failed to parse published date: {}", dateString);
 			return null;
 		}
-	}
-
-	private AddBookResponse buildAddBookResponse(UserBook userBook) {
-		Book book = userBook.getBook();
-
-		AddBookResponse.BookDetail bookDetail = AddBookResponse.BookDetail.builder()
-			.title(book.getTitle())
-			.isbn(book.getIsbn())
-			.publishedDate(book.getPublishedDate())
-			.authors(book.getAuthors())
-			.publisher(book.getPublisher())
-			.translators(book.getTranslators())
-			.thumbnail(book.getThumbnail())
-			.build();
-
-		return AddBookResponse.builder()
-			.userBookId(userBook.getUserBookId())
-			.book(bookDetail)
-			.startDate(userBook.getStartDate())
-			.isReading(userBook.getIsReading())
-			.isFavorite(userBook.getIsFavorite())
-			.createdAt(userBook.getCreatedAt())
-			.message("책이 성공적으로 추가되었습니다.")
-			.build();
 	}
 
 	private UserBookResponse convertToUserBookResponse(UserBook userBook) {

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -66,20 +66,20 @@ public class UserBookService {
 	public List<UserBookResponse> getUserBooks(Long userId, Boolean favorite, Boolean reading) {
 		List<UserBook> userBooks;
 
-		// 쿼리 파라미터에 따른 조건부 조회
+		// 쿼리 파라미터에 따른 조건부 조회 - 모두 updatedAt 기준으로 변경
 		if (favorite != null && favorite && reading != null) {
 			// favorite=true&reading=true/false: 즐겨찾기이면서 읽는 중/완독인 책
-			userBooks = userBookRepository.findByUserUserIdAndIsFavoriteTrueAndIsReadingOrderByCreatedAtDesc(
+			userBooks = userBookRepository.findByUserUserIdAndIsFavoriteTrueAndIsReadingOrderByUpdatedAtDesc(
 				userId, reading);
 		} else if (favorite != null && favorite) {
 			// favorite=true: 즐겨찾기 책만
-			userBooks = userBookRepository.findByUserUserIdAndIsFavoriteTrueOrderByCreatedAtDesc(userId);
+			userBooks = userBookRepository.findByUserUserIdAndIsFavoriteTrueOrderByUpdatedAtDesc(userId);
 		} else if (reading != null) {
 			// reading=true/false: 읽는 중/완독인 책만
-			userBooks = userBookRepository.findByUserUserIdAndIsReadingOrderByCreatedAtDesc(userId, reading);
+			userBooks = userBookRepository.findByUserUserIdAndIsReadingOrderByUpdatedAtDesc(userId, reading);
 		} else {
 			// 파라미터 없음: 전체 책 목록
-			userBooks = userBookRepository.findByUserUserIdOrderByCreatedAtDesc(userId);
+			userBooks = userBookRepository.findByUserUserIdOrderByUpdatedAtDesc(userId);
 		}
 
 		return userBooks.stream()

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -155,9 +155,7 @@ public class UserBookService {
 		Book book = userBook.getBook();
 
 		AddBookResponse.BookDetail bookDetail = AddBookResponse.BookDetail.builder()
-			.bookId(book.getBookId())
 			.title(book.getTitle())
-			.contents(book.getContents())
 			.isbn(book.getIsbn())
 			.publishedDate(book.getPublishedDate())
 			.authors(book.getAuthors())
@@ -181,9 +179,7 @@ public class UserBookService {
 		Book book = userBook.getBook();
 
 		UserBookResponse.BookInfo bookInfo = UserBookResponse.BookInfo.builder()
-			.bookId(book.getBookId())
 			.title(book.getTitle())
-			.contents(book.getContents())
 			.isbn(book.getIsbn())
 			.publishedDate(book.getPublishedDate())
 			.authors(book.getAuthors())

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -89,6 +89,12 @@ public class UserBookService {
 			.toList();
 	}
 
+	@Transactional(readOnly = true)
+	public UserBookResponse getUserBook(Long userId, UUID userBookId) {
+		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
+		return convertToUserBookResponse(userBook);
+	}
+
 	public UserBookResponse markBookAsCompleted(Long userId, UUID userBookId) {
 		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
 


### PR DESCRIPTION
## 작업 내용
POST `/api/books` API 응답 최적화 및 개별 책 조회 기능을 추가했습니다.

## 구현 기능
- **POST `/api/books` 응답 최적화**
  - 성공 시: `userBookId`와 `message`만 응답 (불필요한 필드 제거)
  - 중복 시: 409 Conflict + `userBookId` 포함하여 기존 책 정보 제공 (redirect 용이)
  
- **GET `/api/books/{userBookId}` 엔드포인트 추가**
  - 특정 책 상세 정보 조회
  - 권한 체크: 본인의 책만 조회 가능
  - JWT 인증 필수

- **정렬 기준 변경**
  - GET `/api/books`: `createdAt` → `updatedAt` 기준 정렬
  - 최근 정보 수정한 책이 최상위로 정렬

- **중복 도서 처리 개선**
  - ISBN 검색 후 없을 경우에만 title+author+publisher 조합 검색
  - 중복 도서 판별

## 주요 변경사항
- `AddBookResponse` DTO 간소화 (`userBookId`, `message`만 포함)
- `UserBookService.getUserBook()` 메소드 추가
- `BookController.getUserBook()` 엔드포인트 추가
- Repository 메소드명 변경: `OrderByCreatedAtDesc` → `OrderByUpdatedAtDesc`
- `BookService.findOrCreateBook()` 로직 개선
- `DuplicateBookException`에 `userBookId` 포함
- 불필요한 `buildAddBookResponse()` 메소드 제거

## 참고사항
- 기존 API 호환성 유지 (GET `/api/books` 쿼리 파라미터 동일)
- JWT 인증 및 권한 체크 적용
- 에러 응답 형식 일관성 유지
- Response Body에서 `bookId`, `contents` 필드 제거로 응답 최적화