### PR TITLE
feat: 문장 추가 기능 구현

### DIFF
--- a/src/main/java/com/example/seolab/controller/QuoteController.java
+++ b/src/main/java/com/example/seolab/controller/QuoteController.java
@@ -1,0 +1,110 @@
+package com.example.seolab.controller;
+
+import com.example.seolab.dto.request.AddQuoteRequest;
+import com.example.seolab.dto.request.UpdateQuoteRequest;
+import com.example.seolab.dto.response.QuoteResponse;
+import com.example.seolab.entity.User;
+import com.example.seolab.service.QuoteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/books/{userBookId}/quotes")
+@RequiredArgsConstructor
+@Slf4j
+public class QuoteController {
+
+	private final QuoteService quoteService;
+
+	// POST /api/books/{userBookId}/quotes - 문장 추가
+	@PostMapping
+	public ResponseEntity<QuoteResponse> addQuote(
+		@PathVariable UUID userBookId,
+		@Valid @RequestBody AddQuoteRequest request,
+		Authentication authentication) {
+
+		Long userId = getUserIdFromAuthentication(authentication);
+		QuoteResponse response = quoteService.addQuote(userId, userBookId, request);
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+	}
+
+	// GET /api/books/{userBookId}/quotes - 해당 책의 문장 목록
+	@GetMapping
+	public ResponseEntity<List<QuoteResponse>> getQuotesByUserBook(
+		@PathVariable UUID userBookId,
+		@RequestParam(required = false) Boolean favorite,
+		Authentication authentication) {
+
+		Long userId = getUserIdFromAuthentication(authentication);
+		List<QuoteResponse> quotes = quoteService.getQuotesByUserBook(userId, userBookId, favorite);
+
+		return ResponseEntity.ok(quotes);
+	}
+
+	// GET /api/books/{userBookId}/quotes/{quoteId} - 특정 문장 조회
+	@GetMapping("/{quoteId}")
+	public ResponseEntity<QuoteResponse> getQuote(
+		@PathVariable UUID userBookId,
+		@PathVariable UUID quoteId,
+		Authentication authentication) {
+
+		Long userId = getUserIdFromAuthentication(authentication);
+		QuoteResponse quote = quoteService.getQuoteByUserBookAndQuoteId(userId, userBookId, quoteId);
+
+		return ResponseEntity.ok(quote);
+	}
+
+	// PUT /api/books/{userBookId}/quotes/{quoteId} - 문장 수정
+	@PutMapping("/{quoteId}")
+	public ResponseEntity<QuoteResponse> updateQuote(
+		@PathVariable UUID userBookId,
+		@PathVariable UUID quoteId,
+		@Valid @RequestBody UpdateQuoteRequest request,
+		Authentication authentication) {
+
+		Long userId = getUserIdFromAuthentication(authentication);
+		QuoteResponse response = quoteService.updateQuoteByUserBook(userId, userBookId, quoteId, request);
+
+		return ResponseEntity.ok(response);
+	}
+
+	// DELETE /api/books/{userBookId}/quotes/{quoteId} - 문장 삭제
+	@DeleteMapping("/{quoteId}")
+	public ResponseEntity<Void> deleteQuote(
+		@PathVariable UUID userBookId,
+		@PathVariable UUID quoteId,
+		Authentication authentication) {
+
+		Long userId = getUserIdFromAuthentication(authentication);
+		quoteService.deleteQuoteByUserBook(userId, userBookId, quoteId);
+
+		return ResponseEntity.noContent().build();
+	}
+
+	// PATCH /api/books/{userBookId}/quotes/{quoteId}/favorite - 즐겨찾기
+	@PatchMapping("/{quoteId}/favorite")
+	public ResponseEntity<QuoteResponse> toggleQuoteFavorite(
+		@PathVariable UUID userBookId,
+		@PathVariable UUID quoteId,
+		Authentication authentication) {
+
+		Long userId = getUserIdFromAuthentication(authentication);
+		QuoteResponse response = quoteService.toggleQuoteFavoriteByUserBook(userId, userBookId, quoteId);
+
+		return ResponseEntity.ok(response);
+	}
+
+	private Long getUserIdFromAuthentication(Authentication authentication) {
+		User user = (User) authentication.getPrincipal();
+		return user.getUserId();
+	}
+}

--- a/src/main/java/com/example/seolab/dto/request/AddQuoteRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/AddQuoteRequest.java
@@ -1,0 +1,21 @@
+package com.example.seolab.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddQuoteRequest {
+
+	@NotBlank(message = "문장 내용은 필수입니다.")
+	@Size(max = 1000, message = "문장은 1000자를 초과할 수 없습니다.")
+	private String text;
+
+	private Integer page;
+}

--- a/src/main/java/com/example/seolab/dto/request/UpdateQuoteRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/UpdateQuoteRequest.java
@@ -1,0 +1,21 @@
+package com.example.seolab.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateQuoteRequest {
+
+	@NotBlank(message = "문장 내용은 필수입니다.")
+	@Size(max = 1000, message = "문장은 1000자를 초과할 수 없습니다.")
+	private String text;
+
+	private Integer page;
+}

--- a/src/main/java/com/example/seolab/dto/response/QuoteResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/QuoteResponse.java
@@ -1,0 +1,24 @@
+package com.example.seolab.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuoteResponse {
+	private UUID quoteId;
+	private String text;
+	private Integer page;
+	private Boolean isFavorite;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/UserBookResponse.java
@@ -25,6 +25,7 @@ public class UserBookResponse {
 	private Boolean isReading;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
+	private Long quoteCount;
 
 	@Getter
 	@Setter

--- a/src/main/java/com/example/seolab/entity/Quote.java
+++ b/src/main/java/com/example/seolab/entity/Quote.java
@@ -1,0 +1,61 @@
+package com.example.seolab.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "quotes")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Quote {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "quote_id", columnDefinition = "BINARY(16)")
+	private UUID quoteId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_book_id", nullable = false)
+	private UserBook userBook;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String text;
+
+	@Column(name = "page")
+	private Integer page;
+
+	@Column(name = "is_favorite")
+	@Builder.Default
+	private Boolean isFavorite = false;
+
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@PrePersist
+	protected void onCreate() {
+		createdAt = LocalDateTime.now();
+		updatedAt = LocalDateTime.now();
+	}
+
+	@PreUpdate
+	protected void onUpdate() {
+		updatedAt = LocalDateTime.now();
+	}
+
+	public void toggleFavorite() {
+		this.isFavorite = !this.isFavorite;
+	}
+}

--- a/src/main/java/com/example/seolab/exception/AccessDeniedException.java
+++ b/src/main/java/com/example/seolab/exception/AccessDeniedException.java
@@ -1,0 +1,7 @@
+package com.example.seolab.exception;
+
+public class AccessDeniedException extends RuntimeException {
+	public AccessDeniedException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
@@ -63,6 +63,15 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.CONFLICT).body(error);
 	}
 
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<Map<String, String>> handleAccessDeniedException(
+		AccessDeniedException ex) {
+		Map<String, String> error = new HashMap<>();
+		error.put("message", ex.getMessage());
+		return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+	}
+
+
 	// 이메일 중복 오류를 409 Conflict로 처리
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<Map<String, String>> handleIllegalArgumentException(

--- a/src/main/java/com/example/seolab/repository/QuoteRepository.java
+++ b/src/main/java/com/example/seolab/repository/QuoteRepository.java
@@ -1,0 +1,50 @@
+package com.example.seolab.repository;
+
+import com.example.seolab.entity.Quote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface QuoteRepository extends JpaRepository<Quote, UUID> {
+
+	// 특정 사용자 책의 모든 문장 조회 (최신순)
+	List<Quote> findByUserBookUserBookIdOrderByCreatedAtAsc(UUID userBookId);
+
+	// 특정 사용자 책의 즐겨찾기 문장만 조회
+	List<Quote> findByUserBookUserBookIdAndIsFavoriteTrueOrderByCreatedAtAsc(UUID userBookId);
+
+	// 특정 사용자의 모든 문장 조회 (최신순)
+	@Query("SELECT q FROM Quote q " +
+		"WHERE q.userBook.user.userId = :userId " +
+		"ORDER BY q.createdAt DESC")
+	List<Quote> findByUserIdOrderByCreatedAtAsc(@Param("userId") Long userId);
+
+	// 특정 사용자의 즐겨찾기 문장만 조회
+	@Query("SELECT q FROM Quote q " +
+		"WHERE q.userBook.user.userId = :userId " +
+		"AND q.isFavorite = true " +
+		"ORDER BY q.createdAt DESC")
+	List<Quote> findFavoriteQuotesByUserId(@Param("userId") Long userId);
+
+	// 특정 사용자 책의 문장 개수
+	long countByUserBookUserBookId(UUID userBookId);
+
+	// 특정 사용자의 최근 문장들 (홈 화면용)
+	@Query("SELECT q FROM Quote q " +
+		"WHERE q.userBook.user.userId = :userId " +
+		"ORDER BY q.createdAt DESC")
+	List<Quote> findRecentQuotesByUserId(@Param("userId") Long userId);
+
+	// 사용자와 문장 ID로 조회 (권한 체크용)
+	@Query("SELECT q FROM Quote q " +
+		"WHERE q.quoteId = :quoteId " +
+		"AND q.userBook.user.userId = :userId")
+	Optional<Quote> findByQuoteIdAndUserId(@Param("quoteId") UUID quoteId,
+		@Param("userId") Long userId);
+}

--- a/src/main/java/com/example/seolab/service/QuoteService.java
+++ b/src/main/java/com/example/seolab/service/QuoteService.java
@@ -5,6 +5,7 @@ import com.example.seolab.dto.request.UpdateQuoteRequest;
 import com.example.seolab.dto.response.QuoteResponse;
 import com.example.seolab.entity.Quote;
 import com.example.seolab.entity.UserBook;
+import com.example.seolab.exception.AccessDeniedException;
 import com.example.seolab.repository.QuoteRepository;
 import com.example.seolab.repository.UserBookRepository;
 import lombok.RequiredArgsConstructor;
@@ -192,12 +193,12 @@ public class QuoteService {
 	private UserBook findUserBookByIdAndUserId(UUID userBookId, Long userId) {
 		return userBookRepository.findById(userBookId)
 			.filter(ub -> ub.getUser().getUserId().equals(userId))
-			.orElseThrow(() -> new IllegalArgumentException("접근할 수 없는 책입니다."));
+			.orElseThrow(() -> new AccessDeniedException("접근할 수 없는 책입니다."));
 	}
 
 	private Quote findQuoteByIdAndUserId(UUID quoteId, Long userId) {
 		return quoteRepository.findByQuoteIdAndUserId(quoteId, userId)
-			.orElseThrow(() -> new IllegalArgumentException("접근할 수 없는 문장입니다."));
+			.orElseThrow(() -> new AccessDeniedException("접근할 수 없는 문장입니다."));
 	}
 
 	private QuoteResponse convertToQuoteResponse(Quote quote) {

--- a/src/main/java/com/example/seolab/service/QuoteService.java
+++ b/src/main/java/com/example/seolab/service/QuoteService.java
@@ -1,0 +1,213 @@
+package com.example.seolab.service;
+
+import com.example.seolab.dto.request.AddQuoteRequest;
+import com.example.seolab.dto.request.UpdateQuoteRequest;
+import com.example.seolab.dto.response.QuoteResponse;
+import com.example.seolab.entity.Quote;
+import com.example.seolab.entity.UserBook;
+import com.example.seolab.repository.QuoteRepository;
+import com.example.seolab.repository.UserBookRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class QuoteService {
+
+	private final QuoteRepository quoteRepository;
+	private final UserBookRepository userBookRepository;
+
+	public QuoteResponse addQuote(Long userId, UUID userBookId, AddQuoteRequest request) {
+		log.info("Adding quote to userBook {} for user {}", userBookId, userId);
+
+		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
+
+		Quote quote = Quote.builder()
+			.userBook(userBook)
+			.text(request.getText().trim())
+			.page(request.getPage())
+			.isFavorite(false)
+			.build();
+
+		Quote savedQuote = quoteRepository.save(quote);
+		log.info("Successfully added quote with ID: {}", savedQuote.getQuoteId());
+
+		return convertToQuoteResponse(savedQuote);
+	}
+
+	@Transactional(readOnly = true)
+	public List<QuoteResponse> getQuotesByUserBook(Long userId, UUID userBookId, Boolean favorite) {
+		// 사용자 권한 체크
+		findUserBookByIdAndUserId(userBookId, userId);
+
+		List<Quote> quotes;
+		if (favorite != null && favorite) {
+			quotes = quoteRepository.findByUserBookUserBookIdAndIsFavoriteTrueOrderByCreatedAtAsc(userBookId);
+		} else {
+			quotes = quoteRepository.findByUserBookUserBookIdOrderByCreatedAtAsc(userBookId);
+		}
+
+		return quotes.stream()
+			.map(this::convertToQuoteResponse)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<QuoteResponse> getAllUserQuotes(Long userId, Boolean favorite) {
+		List<Quote> quotes;
+		if (favorite != null && favorite) {
+			quotes = quoteRepository.findFavoriteQuotesByUserId(userId);
+		} else {
+			quotes = quoteRepository.findByUserIdOrderByCreatedAtAsc(userId);
+		}
+
+		return quotes.stream()
+			.map(this::convertToQuoteResponse)
+			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public QuoteResponse getQuote(Long userId, UUID quoteId) {
+		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
+		return convertToQuoteResponse(quote);
+	}
+
+	public QuoteResponse updateQuote(Long userId, UUID quoteId, UpdateQuoteRequest request) {
+		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
+
+		quote.setText(request.getText().trim());
+		quote.setPage(request.getPage());
+
+		Quote savedQuote = quoteRepository.save(quote);
+		log.info("Updated quote with ID: {}", quoteId);
+
+		return convertToQuoteResponse(savedQuote);
+	}
+
+	public QuoteResponse toggleQuoteFavorite(Long userId, UUID quoteId) {
+		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
+		quote.toggleFavorite();
+
+		Quote savedQuote = quoteRepository.save(quote);
+		log.info("Toggled favorite for quote {} ({})", quoteId, quote.getIsFavorite());
+
+		return convertToQuoteResponse(savedQuote);
+	}
+
+	public void deleteQuote(Long userId, UUID quoteId) {
+		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
+		quoteRepository.delete(quote);
+		log.info("Deleted quote with ID: {}", quoteId);
+	}
+
+	// ====================================
+	// UserBook 기반 메서드들 (새로운 RESTful API용)
+	// ====================================
+
+	@Transactional(readOnly = true)
+	public QuoteResponse getQuoteByUserBookAndQuoteId(Long userId, UUID userBookId, UUID quoteId) {
+		// userBook 권한 체크
+		findUserBookByIdAndUserId(userBookId, userId);
+
+		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
+
+		// quote가 해당 userBook에 속하는지 확인
+		if (!quote.getUserBook().getUserBookId().equals(userBookId)) {
+			throw new IllegalArgumentException("해당 책에 속하지 않는 문장입니다.");
+		}
+
+		return convertToQuoteResponse(quote);
+	}
+
+	public QuoteResponse updateQuoteByUserBook(Long userId, UUID userBookId, UUID quoteId, UpdateQuoteRequest request) {
+		// userBook 권한 체크
+		findUserBookByIdAndUserId(userBookId, userId);
+
+		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
+
+		// quote가 해당 userBook에 속하는지 확인
+		if (!quote.getUserBook().getUserBookId().equals(userBookId)) {
+			throw new IllegalArgumentException("해당 책에 속하지 않는 문장입니다.");
+		}
+
+		quote.setText(request.getText().trim());
+		quote.setPage(request.getPage());
+
+		Quote savedQuote = quoteRepository.save(quote);
+		log.info("Updated quote with ID: {} in userBook: {}", quoteId, userBookId);
+
+		return convertToQuoteResponse(savedQuote);
+	}
+
+	public QuoteResponse toggleQuoteFavoriteByUserBook(Long userId, UUID userBookId, UUID quoteId) {
+		// userBook 권한 체크
+		findUserBookByIdAndUserId(userBookId, userId);
+
+		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
+
+		// quote가 해당 userBook에 속하는지 확인
+		if (!quote.getUserBook().getUserBookId().equals(userBookId)) {
+			throw new IllegalArgumentException("해당 책에 속하지 않는 문장입니다.");
+		}
+
+		quote.toggleFavorite();
+
+		Quote savedQuote = quoteRepository.save(quote);
+		log.info("Toggled favorite for quote {} in userBook {} ({})", quoteId, userBookId, quote.getIsFavorite());
+
+		return convertToQuoteResponse(savedQuote);
+	}
+
+	public void deleteQuoteByUserBook(Long userId, UUID userBookId, UUID quoteId) {
+		// userBook 권한 체크
+		findUserBookByIdAndUserId(userBookId, userId);
+
+		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
+
+		// quote가 해당 userBook에 속하는지 확인
+		if (!quote.getUserBook().getUserBookId().equals(userBookId)) {
+			throw new IllegalArgumentException("해당 책에 속하지 않는 문장입니다.");
+		}
+
+		quoteRepository.delete(quote);
+		log.info("Deleted quote with ID: {} from userBook: {}", quoteId, userBookId);
+	}
+
+	@Transactional(readOnly = true)
+	public List<QuoteResponse> getRecentQuotes(Long userId, int limit) {
+		List<Quote> quotes = quoteRepository.findRecentQuotesByUserId(userId);
+		return quotes.stream()
+			.limit(limit)
+			.map(this::convertToQuoteResponse)
+			.toList();
+	}
+
+	private UserBook findUserBookByIdAndUserId(UUID userBookId, Long userId) {
+		return userBookRepository.findById(userBookId)
+			.filter(ub -> ub.getUser().getUserId().equals(userId))
+			.orElseThrow(() -> new IllegalArgumentException("접근할 수 없는 책입니다."));
+	}
+
+	private Quote findQuoteByIdAndUserId(UUID quoteId, Long userId) {
+		return quoteRepository.findByQuoteIdAndUserId(quoteId, userId)
+			.orElseThrow(() -> new IllegalArgumentException("접근할 수 없는 문장입니다."));
+	}
+
+	private QuoteResponse convertToQuoteResponse(Quote quote) {
+		return QuoteResponse.builder()
+			.quoteId(quote.getQuoteId())
+			.text(quote.getText())
+			.page(quote.getPage())
+			.isFavorite(quote.getIsFavorite())
+			.createdAt(quote.getCreatedAt())
+			.updatedAt(quote.getUpdatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -7,7 +7,9 @@ import com.example.seolab.dto.response.UserBookResponse;
 import com.example.seolab.entity.Book;
 import com.example.seolab.entity.User;
 import com.example.seolab.entity.UserBook;
+import com.example.seolab.exception.AccessDeniedException;
 import com.example.seolab.exception.DuplicateBookException;
+import com.example.seolab.repository.QuoteRepository;
 import com.example.seolab.repository.UserBookRepository;
 import com.example.seolab.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,7 @@ public class UserBookService {
 	private final UserBookRepository userBookRepository;
 	private final UserRepository userRepository;
 	private final BookService bookService;
+	private final QuoteRepository quoteRepository;
 
 	public AddBookResponse addBookToUserLibrary(Long userId, AddBookRequest request) {
 		log.info("Adding book to user {} library: {}", userId, request.getTitle());
@@ -128,7 +131,7 @@ public class UserBookService {
 	private UserBook findUserBookByIdAndUserId(UUID userBookId, Long userId) {
 		return userBookRepository.findById(userBookId)
 			.filter(ub -> ub.getUser().getUserId().equals(userId))
-			.orElseThrow(() -> new IllegalArgumentException("접근할 수 없는 책입니다."));
+			.orElseThrow(() -> new AccessDeniedException("접근할 수 없는 책입니다."));
 	}
 
 	private BookDto convertToBookDto(AddBookRequest request) {
@@ -175,6 +178,8 @@ public class UserBookService {
 			.thumbnail(book.getThumbnail())
 			.build();
 
+		long quoteCount = quoteRepository.countByUserBookUserBookId(userBook.getUserBookId());
+
 		return UserBookResponse.builder()
 			.userBookId(userBook.getUserBookId())
 			.book(bookInfo)
@@ -184,6 +189,7 @@ public class UserBookService {
 			.isReading(userBook.getIsReading())
 			.createdAt(userBook.getCreatedAt())
 			.updatedAt(userBook.getUpdatedAt())
+			.quoteCount(quoteCount)
 			.build();
 	}
 }


### PR DESCRIPTION
## 작업 내용
책 별 문장 기록 및 관리 기능을 구현했습니다.

## 구현 기능
- **Quote Entity 및 Repository**
  - UUID 기반 문장 ID 생성
  - UserBook과의 다대일 관계 설정
  - 생성일시 기준 오름차순 정렬 (시간순 누적)

- **RESTful Quote API**
  - `POST /api/books/{userBookId}/quotes` - 문장 추가
  - `GET /api/books/{userBookId}/quotes` - 해당 책의 문장 목록 조회
  - `GET /api/books/{userBookId}/quotes/{quoteId}` - 특정 문장 조회
  - `PUT /api/books/{userBookId}/quotes/{quoteId}` - 문장 수정
  - `DELETE /api/books/{userBookId}/quotes/{quoteId}` - 문장 삭제
  - `PATCH /api/books/{userBookId}/quotes/{quoteId}/favorite` - 즐겨찾기 토글

- **문장 관리 기능**
  - 문장 내용(text) 및 페이지 번호(page) 저장
  - 즐겨찾기 기능 (isFavorite 토글)
  - 즐겨찾기 필터링 조회 지원 (`?favorite=true`)

- **권한 및 보안**
  - 커스텀 AccessDeniedException 추가
  - 리소스 소유권 체크 (403 Forbidden 응답)

- **UserBook 응답 개선**
  - quoteCount 필드 추가로 책별 문장 개수 제공

## 주요 변경사항
- Quote Entity 생성 (text, page, isFavorite, createdAt, updatedAt)
- QuoteRepository 생성 (시간순 정렬 및 필터링 쿼리)
- QuoteService 생성 (CRUD 및 권한 체크 로직)
- QuoteController 생성 (RESTful API 엔드포인트)
- UserBookResponse에 quoteCount 필드 추가
- AccessDeniedException 커스텀 예외 클래스 추가
- GlobalExceptionHandler에 403 Forbidden 응답 처리 추가

## 참고사항
- 문장은 createdAt 오름차순으로 정렬 (독서 기록 순서대로 누적)
- 모든 Quote API는 JWT 인증 필수
- Validation 적용 (문장 내용 필수, 최대 1000자 제한)
- UserBook과 Quote 간 관계 검증