### PR TITLE
feat: 홈 화면에 보여줄 최근 기록한 책, 문장 조회 API 구현

### DIFF
--- a/src/main/java/com/example/seolab/controller/BookController.java
+++ b/src/main/java/com/example/seolab/controller/BookController.java
@@ -2,6 +2,7 @@ package com.example.seolab.controller;
 
 import com.example.seolab.dto.request.AddBookRequest;
 import com.example.seolab.dto.response.AddBookResponse;
+import com.example.seolab.dto.response.RecentBookResponse;
 import com.example.seolab.dto.response.UserBookResponse;
 import com.example.seolab.entity.User;
 import com.example.seolab.service.UserBookService;
@@ -83,6 +84,14 @@ public class BookController {
 		UserBookResponse userBook = userBookService.getUserBook(userId, userBookId);
 
 		return ResponseEntity.ok(userBook);
+	}
+
+	@GetMapping("/recent")
+	public ResponseEntity<RecentBookResponse> getRecentBook(Authentication authentication) {
+		Long userId = getUserIdFromAuthentication(authentication);
+		RecentBookResponse response = userBookService.getRecentBookWithQuotes(userId);
+
+		return ResponseEntity.ok(response);
 	}
 
 	private Long getUserIdFromAuthentication(Authentication authentication) {

--- a/src/main/java/com/example/seolab/dto/response/RecentBookResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/RecentBookResponse.java
@@ -1,0 +1,19 @@
+package com.example.seolab.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecentBookResponse {
+	private UserBookResponse recentBook;
+	private List<QuoteResponse> quotes;
+}

--- a/src/main/java/com/example/seolab/entity/UserBook.java
+++ b/src/main/java/com/example/seolab/entity/UserBook.java
@@ -64,10 +64,6 @@ public class UserBook {
 		updatedAt = LocalDateTime.now();
 	}
 
-	@PreUpdate
-	protected void onUpdate() {
-		updatedAt = LocalDateTime.now();
-	}
 
 	public LocalDate getStartDate() {
 		return createdAt != null ? createdAt.toLocalDate() : null;
@@ -85,6 +81,11 @@ public class UserBook {
 
 	public void toggleFavorite() {
 		this.isFavorite = !this.isFavorite;
+	}
+
+	// 문장 활동시에만 호출되는 메서드
+	public void updateLastActivity() {
+		this.updatedAt = LocalDateTime.now();
 	}
 
 	public boolean isCurrentlyReading() {

--- a/src/main/java/com/example/seolab/repository/QuoteRepository.java
+++ b/src/main/java/com/example/seolab/repository/QuoteRepository.java
@@ -47,4 +47,7 @@ public interface QuoteRepository extends JpaRepository<Quote, UUID> {
 		"AND q.userBook.user.userId = :userId")
 	Optional<Quote> findByQuoteIdAndUserId(@Param("quoteId") UUID quoteId,
 		@Param("userId") Long userId);
+
+	// 특정 사용자 책의 모든 문장 조회 (최신순)
+	List<Quote> findByUserBookUserBookIdOrderByCreatedAtDesc(UUID userBookId);
 }

--- a/src/main/java/com/example/seolab/repository/UserBookRepository.java
+++ b/src/main/java/com/example/seolab/repository/UserBookRepository.java
@@ -37,4 +37,7 @@ public interface UserBookRepository extends JpaRepository<UserBook, UUID> {
 		"ORDER BY ub.updatedAt DESC")
 	List<UserBook> findRecentBooks(@Param("userId") Long userId,
 		@Param("isReading") Boolean isReading);
+
+	// updated_at 기준으로 가장 최근 책 1개 조회
+	Optional<UserBook> findTopByUserUserIdOrderByUpdatedAtDesc(Long userId);
 }

--- a/src/main/java/com/example/seolab/service/QuoteService.java
+++ b/src/main/java/com/example/seolab/service/QuoteService.java
@@ -38,6 +38,10 @@ public class QuoteService {
 			.build();
 
 		Quote savedQuote = quoteRepository.save(quote);
+
+		userBook.updateLastActivity();
+		userBookRepository.save(userBook);
+
 		log.info("Successfully added quote with ID: {}", savedQuote.getQuoteId());
 
 		return convertToQuoteResponse(savedQuote);
@@ -87,6 +91,10 @@ public class QuoteService {
 		quote.setPage(request.getPage());
 
 		Quote savedQuote = quoteRepository.save(quote);
+
+		quote.getUserBook().updateLastActivity();
+		userBookRepository.save(quote.getUserBook());
+
 		log.info("Updated quote with ID: {}", quoteId);
 
 		return convertToQuoteResponse(savedQuote);
@@ -104,13 +112,16 @@ public class QuoteService {
 
 	public void deleteQuote(Long userId, UUID quoteId) {
 		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
+		UserBook userBook = quote.getUserBook();
+
 		quoteRepository.delete(quote);
+
+		userBook.updateLastActivity();
+		userBookRepository.save(userBook);
+
 		log.info("Deleted quote with ID: {}", quoteId);
 	}
 
-	// ====================================
-	// UserBook 기반 메서드들 (새로운 RESTful API용)
-	// ====================================
 
 	@Transactional(readOnly = true)
 	public QuoteResponse getQuoteByUserBookAndQuoteId(Long userId, UUID userBookId, UUID quoteId) {
@@ -129,7 +140,7 @@ public class QuoteService {
 
 	public QuoteResponse updateQuoteByUserBook(Long userId, UUID userBookId, UUID quoteId, UpdateQuoteRequest request) {
 		// userBook 권한 체크
-		findUserBookByIdAndUserId(userBookId, userId);
+		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
 
 		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
 
@@ -142,6 +153,10 @@ public class QuoteService {
 		quote.setPage(request.getPage());
 
 		Quote savedQuote = quoteRepository.save(quote);
+
+		userBook.updateLastActivity();
+		userBookRepository.save(userBook);
+
 		log.info("Updated quote with ID: {} in userBook: {}", quoteId, userBookId);
 
 		return convertToQuoteResponse(savedQuote);
@@ -168,7 +183,7 @@ public class QuoteService {
 
 	public void deleteQuoteByUserBook(Long userId, UUID userBookId, UUID quoteId) {
 		// userBook 권한 체크
-		findUserBookByIdAndUserId(userBookId, userId);
+		UserBook userBook = findUserBookByIdAndUserId(userBookId, userId);
 
 		Quote quote = findQuoteByIdAndUserId(quoteId, userId);
 
@@ -178,6 +193,10 @@ public class QuoteService {
 		}
 
 		quoteRepository.delete(quote);
+
+		userBook.updateLastActivity();
+		userBookRepository.save(userBook);
+
 		log.info("Deleted quote with ID: {} from userBook: {}", quoteId, userBookId);
 	}
 

--- a/src/main/java/com/example/seolab/service/UserBookService.java
+++ b/src/main/java/com/example/seolab/service/UserBookService.java
@@ -126,7 +126,7 @@ public class UserBookService {
 		List<Quote> recentQuotes = quoteRepository.findByUserBookUserBookIdOrderByCreatedAtDesc(
 				recentUserBook.getUserBookId())
 			.stream()
-			.limit(4)
+			.limit(10)
 			.toList();
 
 		List<QuoteResponse> quoteResponses = recentQuotes.stream()


### PR DESCRIPTION
## 작업 내용
홈 화면에 보여줄 최근 책과 해당 책의 최근 문장 10개를 조회하는 API를 구현했습니다.

## 구현 기능
- **GET /api/books/recent API**
  - 사용자의 가장 최근에 문장을 기록한 책 1개 조회
  - 해당 책의 최근 문장 10개 조회 (created_at 기준 최신순)
  - 책이 없는 경우 null, 문장이 없는 경우 빈 배열 반환

- **UserBook updated_at 갱신 로직 변경**
  - 문장 추가/수정/삭제시에만 updated_at 갱신
  - 즐겨찾기/완독 상태 변경시에는 updated_at 갱신하지 않음
  - 홈화면에서 "실제 독서 활동"이 있었던 책을 우선 표시

## 주요 변경사항
- **새로운 DTO 생성**
  - `RecentBookResponse` - 래퍼 구조로 recentBook + quotes

- **UserBook 엔티티 수정**
  - `@PreUpdate` 어노테이션 제거 (수동 updated_at 관리)
  - `updateLastActivity()` 메서드 추가
  - `toggleReading()`, `toggleFavorite()` 메서드에서 updated_at 갱신 로직 제거

- **QuoteService 수정**
  - 문장 추가/수정/삭제시 `userBook.updateLastActivity()` 호출
  - 문장 즐겨찾기 토글시에는 UserBook updated_at 갱신하지 않음

- **컨트롤러 및 서비스**
  - `BookController.getRecentBook()` 엔드포인트 추가
  - `UserBookService.getRecentBookWithQuotes()` 메서드 구현

## 참고사항
- 책이 없는 사용자에게는 `{ "recentBook": null, "quotes": [] }` 반환