### PR TITLE
feat : 회원가입시 이메일 인증 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -37,6 +38,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/seolab/config/AsyncConfig.java
+++ b/src/main/java/com/example/seolab/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.example.seolab.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+	@Bean(name = "taskExecutor")
+	public Executor taskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(2);
+		executor.setMaxPoolSize(5);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("Email-");
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/java/com/example/seolab/config/RedisConfig.java
+++ b/src/main/java/com/example/seolab/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package com.example.seolab.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		// String 직렬화 설정
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/example/seolab/controller/AuthController.java
+++ b/src/main/java/com/example/seolab/controller/AuthController.java
@@ -1,7 +1,13 @@
 package com.example.seolab.controller;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.example.seolab.dto.request.EmailVerificationRequest;
 import com.example.seolab.dto.request.LoginRequest;
 import com.example.seolab.dto.request.SignUpRequest;
+import com.example.seolab.dto.request.VerifyCodeRequest;
+import com.example.seolab.dto.response.EmailVerificationResponse;
 import com.example.seolab.dto.response.LoginResponse;
 import com.example.seolab.dto.response.SignUpResponse;
 import com.example.seolab.dto.response.TokenResponse;
@@ -65,6 +71,28 @@ public class AuthController {
 	public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest signUpRequest) {
 		SignUpResponse signUpResponse = authService.signUp(signUpRequest);
 		return ResponseEntity.status(HttpStatus.CREATED).body(signUpResponse);
+	}
+
+	@PostMapping("/verify/request")
+	public ResponseEntity<EmailVerificationResponse> sendVerificationCode(
+		@Valid @RequestBody EmailVerificationRequest request) {
+
+		EmailVerificationResponse response = authService.sendVerificationCode(request.getEmail());
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/verify")
+	public ResponseEntity<Map<String, String>> verifyCode(@Valid @RequestBody VerifyCodeRequest request) {
+		boolean isValid = authService.verifyCode(request.getEmail(), request.getCode());
+
+		Map<String, String> response = new HashMap<>();
+		if (isValid) {
+			response.put("message", "이메일 인증이 완료되었습니다.");
+			return ResponseEntity.ok(response);
+		} else {
+			response.put("message", "인증 코드가 올바르지 않거나 만료되었습니다.");
+			return ResponseEntity.badRequest().body(response);
+		}
 	}
 
 	@GetMapping("/me")

--- a/src/main/java/com/example/seolab/dto/request/EmailVerificationRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/EmailVerificationRequest.java
@@ -1,0 +1,19 @@
+package com.example.seolab.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailVerificationRequest {
+
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	private String email;
+}

--- a/src/main/java/com/example/seolab/dto/request/SignUpRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/SignUpRequest.java
@@ -2,6 +2,7 @@ package com.example.seolab.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,9 +22,10 @@ public class SignUpRequest {
 	private String email;
 
 	@NotBlank(message = "비밀번호는 필수입니다.")
+	@Size(min = 8, max = 20, message = "비밀번호는 8-20자 사이여야 합니다.")
 	@Pattern(
-		regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
-		message = "올바른 비밀번호 형식이 아닙니다. (최소 8-20자, 대소문자, 숫자, 특수문자 각 1개 이상)"
+		regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*]).*$",
+		message = "대소문자, 숫자, 특수문자 포함"
 	)
 	private String password;
 }

--- a/src/main/java/com/example/seolab/dto/request/VerifyCodeRequest.java
+++ b/src/main/java/com/example/seolab/dto/request/VerifyCodeRequest.java
@@ -1,0 +1,24 @@
+package com.example.seolab.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerifyCodeRequest {
+
+	@NotBlank(message = "이메일은 필수입니다.")
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	private String email;
+
+	@NotBlank(message = "인증 코드는 필수입니다.")
+	@Size(min = 6, max = 6, message = "인증 코드는 6자리여야 합니다.")
+	private String code;
+}

--- a/src/main/java/com/example/seolab/dto/response/EmailVerificationResponse.java
+++ b/src/main/java/com/example/seolab/dto/response/EmailVerificationResponse.java
@@ -1,0 +1,17 @@
+package com.example.seolab.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmailVerificationResponse {
+	private String message;
+	private long expiresInSeconds;
+}

--- a/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/seolab/exception/GlobalExceptionHandler.java
@@ -102,4 +102,18 @@ public class GlobalExceptionHandler {
 		error.put("message", "유효하지 않은 토큰입니다.");
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
 	}
+
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<Map<String, String>> handleRuntimeException(RuntimeException ex) {
+		Map<String, String> error = new HashMap<>();
+
+		// 이메일 발송 실패 등의 런타임 에러 처리
+		if (ex.getMessage().contains("이메일 발송")) {
+			error.put("message", "이메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.");
+			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(error);
+		}
+
+		error.put("message", ex.getMessage());
+		return ResponseEntity.badRequest().body(error);
+	}
 }

--- a/src/main/java/com/example/seolab/service/EmailService.java
+++ b/src/main/java/com/example/seolab/service/EmailService.java
@@ -1,0 +1,78 @@
+package com.example.seolab.service;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+
+	private final JavaMailSender mailSender;
+
+	@Value("${spring.mail.username}")
+	private String fromEmail;
+
+	@Async
+	public void sendVerificationEmail(String toEmail, String verificationCode) {
+		try {
+			MimeMessage message = mailSender.createMimeMessage();
+			MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+			helper.setFrom(fromEmail);
+			helper.setTo(toEmail);
+			helper.setSubject("도토리 - 이메일 인증 코드");
+			helper.setText(createHtmlEmailContent(verificationCode), true); // HTML 모드
+
+			mailSender.send(message);
+			log.info("HTML verification email sent to: {}", toEmail);
+		} catch (Exception e) {
+			log.error("Failed to send verification email to: {}", toEmail, e);
+			throw new RuntimeException("이메일 발송에 실패했습니다.", e);
+		}
+	}
+
+	private String createHtmlEmailContent(String verificationCode) {
+		return String.format("""
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset="UTF-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                <title>도토리 이메일 인증</title>
+            </head>
+            <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+                
+                <div style="background: #ffffff; padding: 40px; border-radius: 0 0 10px 10px; box-shadow: 0 4px 6px rgba(0,0,0,0.1);">
+                    <h2 style="color: #333; text-align: center; margin-bottom: 30px;">이메일 인증 코드</h2>
+                    
+                    <div style="background: #f8f9fa; border: 2px dashed #667eea; border-radius: 8px; padding: 30px; text-align: center; margin: 30px 0;">
+                        <p style="font-size: 14px; color: #666; margin: 0 0 10px 0;">인증 코드</p>
+                        <h1 style="font-size: 36px; font-weight: bold; color: #667eea; margin: 0; letter-spacing: 5px; font-family: 'Courier New', monospace;">%s</h1>
+                    </div>
+                    
+                    <div style="background: #fff3cd; border: 1px solid #ffeaa7; border-radius: 6px; padding: 15px; margin: 25px 0;">
+                        <p style="margin: 0; font-size: 14px; color: #856404;">
+                            <strong>⚠️</strong> 인증 코드는 <strong>5분 후에 만료</strong>됩니다.
+                        </p>
+                    </div>
+                    
+                    <div style="margin-top: 40px; padding-top: 30px; border-top: 1px solid #eee; text-align: center;">
+                        <p style="color: #666; font-size: 14px; margin: 0;">
+                            본 이메일은 도토리 회원가입을 위해 발송되었습니다.<br>
+                            인증시간이 만료되었을 경우, 인증번호 재발송을 진행해 주시기 바랍니다.
+                        </p>
+                    </div>
+                </div>
+            </body>
+            </html>
+            """, verificationCode);
+	}
+}

--- a/src/main/java/com/example/seolab/service/EmailVerificationService.java
+++ b/src/main/java/com/example/seolab/service/EmailVerificationService.java
@@ -1,0 +1,100 @@
+package com.example.seolab.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailVerificationService {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final EmailService emailService;
+
+	@Value("${email.verification.expiration}")
+	private long expirationSeconds;
+
+	@Value("${email.verification.code-length}")
+	private int codeLength;
+
+	private static final String VERIFICATION_PREFIX = "email_verification:";
+	private static final String VERIFIED_PREFIX = "email_verified:";
+
+	public void sendVerificationCode(String email) {
+		// 이미 인증된 이메일인지 확인
+		if (isEmailVerified(email)) {
+			throw new IllegalArgumentException("이미 인증된 이메일입니다.");
+		}
+
+		// 인증 코드 생성
+		String verificationCode = generateVerificationCode();
+
+		// Redis에 저장 (TTL 설정)
+		String key = VERIFICATION_PREFIX + email;
+		redisTemplate.opsForValue().set(key, verificationCode, Duration.ofSeconds(expirationSeconds));
+
+		// 이메일 발송
+		emailService.sendVerificationEmail(email, verificationCode);
+
+		log.info("Verification code sent to email: {}", email);
+	}
+
+	public boolean verifyCode(String email, String code) {
+		String key = VERIFICATION_PREFIX + email;
+		String storedCode = (String) redisTemplate.opsForValue().get(key);
+
+		if (storedCode == null) {
+			log.warn("Verification code not found or expired for email: {}", email);
+			return false;
+		}
+
+		if (!storedCode.equals(code)) {
+			log.warn("Invalid verification code for email: {}", email);
+			return false;
+		}
+
+		// 인증 성공 시 해당 키 삭제하고 인증 완료 상태 저장
+		redisTemplate.delete(key);
+		markEmailAsVerified(email);
+
+		log.info("Email verification successful for: {}", email);
+		return true;
+	}
+
+	public boolean isEmailVerified(String email) {
+		String verifiedKey = VERIFIED_PREFIX + email;
+		return Boolean.TRUE.equals(redisTemplate.hasKey(verifiedKey));
+	}
+
+	private void markEmailAsVerified(String email) {
+		String verifiedKey = VERIFIED_PREFIX + email;
+		// 10분간 인증 완료 상태 유지 (회원가입 완료까지의 시간)
+		redisTemplate.opsForValue().set(verifiedKey, "verified", Duration.ofMinutes(10));
+	}
+
+	public void clearVerifiedStatus(String email) {
+		String verifiedKey = VERIFIED_PREFIX + email;
+		redisTemplate.delete(verifiedKey);
+	}
+
+	private String generateVerificationCode() {
+		SecureRandom random = new SecureRandom();
+		StringBuilder code = new StringBuilder();
+
+		for (int i = 0; i < codeLength; i++) {
+			code.append(random.nextInt(10));
+		}
+
+		return code.toString();
+	}
+
+	public long getExpirationSeconds() {
+		return expirationSeconds;
+	}
+}


### PR DESCRIPTION
## 작업 내용
Redis 기반 이메일 인증 시스템을 구현하여 회원가입 시 이메일 인증을 필수로 해야하는 기능을 추가했습니다.

## 구현 기능
- **이메일 인증 시스템**
  - 6자리 SecureRandom 인증 코드 생성
  - Redis 기반 코드 저장 및 TTL 관리 (5분)
  - HTML 형식 이메일 발송 (비동기 처리)

- **API 엔드포인트**
  - `POST /api/auth/verify/request` - 이메일 인증 코드 발송
  - `POST /api/auth/verify` - 인증 코드 검증
  - `POST /api/auth/signup` - 이메일 인증 완료 후 회원가입 (기존 API 수정)

- **보안 강화**
  - 회원가입 시 이메일 인증 필수
  - 인증 코드 5분 만료
  - 인증 완료 상태 10분 유지
  - 중복 이메일 사전 차단

## 주요 변경사항
- **Redis 연결 설정** (Lettuce, StringRedisSerializer)
- **이메일 발송 설정** (Gmail SMTP, MimeMessage 사용)
- **새로운 서비스 클래스**
  - EmailService (HTML 이메일 발송)
  - EmailVerificationService (Redis 기반 코드 관리)
- **DTO 추가**
  - EmailVerificationRequest, VerifyCodeRequest
  - EmailVerificationResponse
- **SignUpRequest 수정** (verificationCode 필드 제거, 비밀번호 정규식 프론트엔드와 통일)
- **AuthService.signUp() 수정** (이메일 인증 여부 확인 로직 추가)
- **비동기 처리 설정** (ThreadPoolTaskExecutor)

## 참고사항
- **이메일 발송 비동기 처리**로 응답 속도 향상 (2-5초 → 즉시)
- **보안**: 인증 코드는 일회성, 자동 만료
- **확장성**: SMS 인증 등 추가 인증 방식 확장 가능한 구조
